### PR TITLE
docs: unhide Selfie Check (Beta) from nav

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -82,15 +82,14 @@
           },
           {
             "group": "Credentials",
-            "pages": ["world-id/credentials/legacy-presets"]
+            "pages": [
+              "world-id/credentials/legacy-presets",
+              "world-id/selfie-check/overview"
+            ]
           },
           {
             "group": "Migration",
             "pages": ["world-id/4-0-migration"]
-          },
-          {
-            "group": "Selfie Check (Beta)",
-            "pages": ["world-id/selfie-check/overview"]
           },
           {
             "group": "Technical Reference",

--- a/docs.json
+++ b/docs.json
@@ -90,7 +90,6 @@
           },
           {
             "group": "Selfie Check (Beta)",
-            "hidden": true,
             "pages": ["world-id/selfie-check/overview"]
           },
           {


### PR DESCRIPTION
## Summary
- Removes the `"hidden": true` flag from the Selfie Check (Beta) group in `docs.json` so the existing `world-id/selfie-check/overview` page is reachable from the World ID sidebar.
- Devs have been asking for it; the page already existed but was hidden from when the feature was unannounced.

## Test plan
- [ ] Verify the "Selfie Check (Beta)" group appears in the World ID nav between "Migration" and "Technical Reference".