### PR TITLE
put selfie check docs in their own section

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -83,7 +83,12 @@
           {
             "group": "Credentials",
             "pages": [
-              "world-id/credentials/legacy-presets",
+              "world-id/credentials/legacy-presets"
+            ]
+          },
+          {
+            "group": "Selfie Check",
+            "pages": [
               "world-id/selfie-check/overview"
             ]
           },

--- a/docs.json
+++ b/docs.json
@@ -83,12 +83,7 @@
           {
             "group": "Credentials",
             "pages": [
-              "world-id/credentials/legacy-presets"
-            ]
-          },
-          {
-            "group": "Selfie Check",
-            "pages": [
+              "world-id/credentials/legacy-presets",
               "world-id/selfie-check/overview"
             ]
           },

--- a/world-id/selfie-check/overview.mdx
+++ b/world-id/selfie-check/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Overview"
+title: "Selfie Check Overview"
 description: "**Selfie Check (Beta)** is a new, low-assurance biometric credential within the World ID ecosystem."
 "og:image": "https://raw.githubusercontent.com/worldcoin/developer-docs/main/images/docs/docs-meta.png"
 "twitter:image": "https://raw.githubusercontent.com/worldcoin/developer-docs/main/images/docs/docs-meta.png"


### PR DESCRIPTION
Previously:
<img width="508" height="365" alt="image" src="https://github.com/user-attachments/assets/8ecaa28d-ca0f-4f1c-a560-02de633c9d35" />

Now:
<img width="684" height="585" alt="image" src="https://github.com/user-attachments/assets/8bbf3f0d-bb96-45a7-a969-28285ef1c145" />

