### PR TITLE
reword world id overview

### DIFF
--- a/world-id/overview.mdx
+++ b/world-id/overview.mdx
@@ -1,16 +1,16 @@
 ---
 title: "World ID"
 sidebarTitle: "Overview"
-description: "Anonymous proof of human credential for the age of AI"
+description: ""
 ---
 
 import { Quickstart } from "/snippets/quickstart.jsx";
 
-World ID is an anonymous proof of human credential that lets people prove they are a real and unique human online without sharing personal information.
+World ID is a privacy-preserving protocol that lets people prove they are real and unique online without sharing personal information.
 
-In the age of AI, it gives relying parties a high-assurance signal to stop bots, duplicate accounts, and abuse while keeping onboarding fast and privacy-preserving.
+It gives developers a high-assurance trust layer to stop bots, duplicate accounts, and abuse — while keeping onboarding fast and user data off your servers.
 
-World ID credentials extend that trust layer with additional proofs, like proof of age and document-backed signals, without exposing underlying user data.
+Through credentials like Proof of Human, Document, and Selfie Check, World ID extends that trust layer with additional proofs without exposing underlying user data.
 
 {/* cspell:ignore worldcoin idkit orblegacy rp_context app_id rp_id selfie-check sybil PoH CAPTCHAs NFC unlinkable nullifier */}
 


### PR DESCRIPTION
input welcome, but world id isn't a credential anymore. Description just came off as redundant so i removed it.