### PR TITLE
Fix command syntax for Codex transport option

### DIFF
--- a/mini-apps/quick-start/installing.mdx
+++ b/mini-apps/quick-start/installing.mdx
@@ -105,7 +105,7 @@ The [World Docs MCP](/model-context-protocol/world-docs) lets any coding assista
   </Tab>
   <Tab title="Codex">
     ```bash
-    codex mcp add --transport http world https://docs.world.org/mcp
+    codex mcp add -- --transport http world https://docs.world.org/mcp
     ```
   </Tab>
   <Tab title="Cursor">


### PR DESCRIPTION
due to error: unexpected argument '--transport' found

  tip: to pass '--transport' as a value, use '-- --transport'


Logs
```

(.venv) abdulrehmanbhidya@abdulrehmans-MacBook-Pro WorldPrize % codex mcp add --transport http world https://docs.world.org/mcp

error: unexpected argument '--transport' found

  tip: to pass '--transport' as a value, use '-- --transport'

Usage: codex mcp add [OPTIONS] <NAME> (--url <URL> | -- <COMMAND>...)

For more information, try '--help'.
(.venv) abdulrehmanbhidya@abdulrehmans-MacBook-Pro WorldPrize % codex mcp add -- --transport http world https://docs.world.org/mcp

Added global MCP server '--transport'.
(.venv) abdulrehmanbhidya@abdulrehmans-MacBook-Pro WorldPrize % 
```