### PR TITLE
docs(idkit): restructure credential presets

### DIFF
--- a/world-id/idkit/credentials.mdx
+++ b/world-id/idkit/credentials.mdx
@@ -4,7 +4,7 @@ title: "Configure Credentials"
 "twitter:image": "https://raw.githubusercontent.com/worldcoin/developer-docs/main/images/docs/docs-meta.png"
 ---
 
-{/* cspell:ignore NFC eID liveness nullifier nullifiers */}
+{/* cspell:ignore NFC liveness */}
 
 A [Credential](https://docs.rs/world-id-primitives/latest/world_id_primitives/credential/struct.Credential.html) is a statement an issuer makes about a World ID holder. In IDKit, the credential you request determines what the user proves to your application.
 
@@ -15,7 +15,6 @@ A [Credential](https://docs.rs/world-id-primitives/latest/world_id_primitives/cr
 | Proof of Human | The user is a unique human, backed by anonymous biometric verification by the Orb. | `proofOfHuman` |
 | Passport | The user holds a verified NFC passport credential. | `passport` |
 | Selfie Check | A low-assurance biometric credential using the device camera for liveness and facial similarity. | `selfieCheckLegacy` today. World ID 4.0 support is rolling out soon. |
-| Identity Check | An attestation that a document-backed property about the user matches your requested attributes. | `identityCheck` with attributes like `minimum_age`, `nationality`, or `document_type`. |
 
 You can also add a liveness check to any preset with `require_user_presence`.
 
@@ -25,7 +24,7 @@ You can also add a liveness check to any preset with `require_user_presence`.
 
 # SDK presets
 
-This page focuses on preset helpers for common credential requests: `proofOfHuman`, `passport`, `selfieCheckLegacy`, `identityCheck`, and the legacy presets.
+This page focuses on preset helpers for common credential requests: `proofOfHuman`, `passport`, `selfieCheckLegacy`, and the legacy presets.
 
 The snippets below use `rp_context` as if it was already generated and signed by your backend. See [Integrate IDKit](/world-id/idkit/integrate) for the full RP-signing flow.
 
@@ -141,68 +140,6 @@ const preset = selfieCheckLegacy({ signal: "user-123" });
 />;
 ```
 </CodeGroup>
-
-## Identity Check
-
-Identity Check is for attesting properties about a user from document-backed credentials. You can request attributes such as:
-
-| Attribute | Value type |
-| --- | --- |
-| `document_type` | `"passport"` or `"eid"` |
-| `document_number` | `string` |
-| `issuing_country` | ISO 3166-1 alpha-3 country code |
-| `full_name` | `string` |
-| `minimum_age` | `number` |
-| `nationality` | ISO 3166-1 alpha-3 country code |
-
-Set `require_proof_of_humanity: true` when the identity attestation should also require Proof of Human.
-
-<CodeGroup title="Identity Check">
-```typescript title="JavaScript"
-import { IDKit, identityCheck } from "@worldcoin/idkit-core";
-
-const preset = identityCheck({
-  attributes: [
-    { type: "document_type", value: "passport" },
-    { type: "minimum_age", value: 18 },
-  ],
-  require_proof_of_humanity: true,
-});
-
-const request = await IDKit.request({
-  app_id: "app_xxxxx",
-  action: "my-action",
-  rp_context,
-  allow_legacy_proofs: false,
-}).preset(preset);
-```
-
-```tsx title="React"
-import { IDKitRequestWidget, identityCheck } from "@worldcoin/idkit";
-
-const preset = identityCheck({
-  attributes: [
-    { type: "document_type", value: "passport" },
-    { type: "minimum_age", value: 18 },
-  ],
-  require_proof_of_humanity: true,
-});
-
-<IDKitRequestWidget
-  open={open}
-  onOpenChange={setOpen}
-  app_id="app_xxxxx"
-  action="my-action"
-  rp_context={rpContext}
-  allow_legacy_proofs={false}
-  preset={preset}
-  handleVerify={handleVerify}
-  onSuccess={(result) => { /* ... */ }}
-/>;
-```
-</CodeGroup>
-
-Successful Identity Check responses include `identity_attested` so your backend can distinguish whether the requested attributes matched.
 
 ## User presence and liveness
 

--- a/world-id/idkit/credentials.mdx
+++ b/world-id/idkit/credentials.mdx
@@ -4,249 +4,262 @@ title: "Configure Credentials"
 "twitter:image": "https://raw.githubusercontent.com/worldcoin/developer-docs/main/images/docs/docs-meta.png"
 ---
 
-A [Credential](https://docs.rs/world-id-primitives/latest/world_id_primitives/credential/struct.Credential.html) is a statement an issuer makes about a World ID holder. Fundamentally, when you as an RP request a proof, the choice of Credential matters significantly to fulfill your use case. For example, if you want to protect an action that should only be done once per human, you probably want to use the Proof of Human credential.
+{/* cspell:ignore NFC eID liveness nullifier nullifiers */}
 
-# World ID 4.0 Presets
+A [Credential](https://docs.rs/world-id-primitives/latest/world_id_primitives/credential/struct.Credential.html) is a statement an issuer makes about a World ID holder. In IDKit, the credential you request determines what the user proves to your application.
 
-These presets create World ID 4.0 proof requests and automatically fall back to the matching legacy proof when a World ID 4.0 proof is not available. If you have an existing integration using legacy presets, please take a look at the [migration guide](/world-id/4-0-migration).
+# What you can request with IDKit
 
-## `proofOfHuman`
+| Offering | What it proves | Common SDK path |
+| --- | --- | --- |
+| Proof of Human | The user is a unique human, backed by anonymous biometric verification by the Orb. | `proofOfHuman` |
+| Passport | The user holds a verified NFC passport credential. | `passport` |
+| Selfie Check | A low-assurance biometric credential using the device camera for liveness and facial similarity. | `selfieCheckLegacy` today. World ID 4.0 support is rolling out soon. |
+| Identity Check | An attestation that a document-backed property about the user matches your requested attributes. | `identityCheck` with attributes like `minimum_age`, `nationality`, or `document_type`. |
 
-Requires Proof of Human. Falls back to an Orb legacy proof.
+You can also add a liveness check to any preset with `require_user_presence`.
 
-<CodeGroup title="proofOfHuman">
+<Note>
+  If you have an existing legacy integration, see the [World ID 4.0 migration guide](/world-id/4-0-migration).
+</Note>
+
+# SDK presets
+
+This page focuses on preset helpers for common credential requests: `proofOfHuman`, `passport`, `selfieCheckLegacy`, `identityCheck`, and the legacy presets.
+
+The snippets below use `rp_context` as if it was already generated and signed by your backend. See [Integrate IDKit](/world-id/idkit/integrate) for the full RP-signing flow.
+
+## Proof of Human
+
+Use `proofOfHuman` for the current World ID 4.0 Proof of Human credential. The preset also includes legacy Orb fallback for users who do not yet have a World ID 4.0 proof available.
+
+<CodeGroup title="Proof of Human">
 ```typescript title="JavaScript"
 import { IDKit, proofOfHuman } from "@worldcoin/idkit-core";
+
+const preset = proofOfHuman({ signal: "user-123" });
 
 const request = await IDKit.request({
   app_id: "app_xxxxx",
   action: "my-action",
-  rp_context: { /* ... */ },
-}).preset(proofOfHuman({ signal: "user-123" }));
+  rp_context,
+  allow_legacy_proofs: true,
+}).preset(preset);
 ```
 
 ```tsx title="React"
 import { IDKitRequestWidget, proofOfHuman } from "@worldcoin/idkit";
 
+const preset = proofOfHuman({ signal: "user-123" });
+
 <IDKitRequestWidget
+  open={open}
+  onOpenChange={setOpen}
   app_id="app_xxxxx"
   action="my-action"
-  rp_context={rp_context}
-  preset={proofOfHuman({ signal: "user-123" })}
+  rp_context={rpContext}
+  allow_legacy_proofs={true}
+  preset={preset}
+  handleVerify={handleVerify}
   onSuccess={(result) => { /* ... */ }}
 />;
 ```
 </CodeGroup>
 
-## `passport`
+## Passport
 
-Requires a Passport credential. Falls back to a Document legacy proof.
+Use `passport` for the current World ID 4.0 Passport credential. The preset also includes legacy Document fallback for users who do not yet have a World ID 4.0 proof available.
 
-<CodeGroup title="passport">
+<CodeGroup title="Passport">
 ```typescript title="JavaScript"
 import { IDKit, passport } from "@worldcoin/idkit-core";
+
+const preset = passport({ signal: "user-123" });
 
 const request = await IDKit.request({
   app_id: "app_xxxxx",
   action: "my-action",
-  rp_context: { /* ... */ },
-}).preset(passport({ signal: "user-123" }));
+  rp_context,
+  allow_legacy_proofs: true,
+}).preset(preset);
 ```
 
 ```tsx title="React"
 import { IDKitRequestWidget, passport } from "@worldcoin/idkit";
 
+const preset = passport({ signal: "user-123" });
+
 <IDKitRequestWidget
+  open={open}
+  onOpenChange={setOpen}
   app_id="app_xxxxx"
   action="my-action"
-  rp_context={rp_context}
-  preset={passport({ signal: "user-123" })}
+  rp_context={rpContext}
+  allow_legacy_proofs={true}
+  preset={preset}
+  handleVerify={handleVerify}
   onSuccess={(result) => { /* ... */ }}
 />;
 ```
 </CodeGroup>
 
-## Parameters
+## Selfie Check
 
-Both World ID 4.0 presets accept an optional `signal` parameter:
+Selfie Check is available through the legacy preset today and returns a World ID 3.0 Face proof. World ID 4.0 support is rolling out soon.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `signal` | `string?` | Binds specific context into the proof (e.g. user ID, wallet address). Your backend should enforce the same value. |
+Learn more in [Selfie Check](/world-id/credentials/11).
 
-# Legacy Presets
-
-Legacy presets only return World ID 3.0 proofs. These function the same as `VerificationLevel` from previous IDKit versions.
-
-## `orbLegacy`
-
-Requires Orb verification.
-
-<CodeGroup title="orbLegacy">
-```typescript title="JavaScript"
-import { IDKit, orbLegacy } from "@worldcoin/idkit-core";
-
-const request = await IDKit.request({
-  app_id: "app_xxxxx",
-  action: "my-action",
-  rp_context: { /* ... */ },
-}).preset(orbLegacy({ signal: "user-123" }));
-```
-
-```swift title="Swift"
-import IDKit
-
-let request = try IDKit.request(config: config)
-    .preset(orbLegacy(signal: "user-123"))
-```
-
-```kotlin title="Kotlin"
-import com.worldcoin.idkit.orbLegacy
-
-val request = IDKit.request(config)
-    .preset(orbLegacy(signal = "user-123"))
-```
-</CodeGroup>
-
-## `secureDocumentLegacy`
-
-Requires at least a Secure Document verification. Returns the user's highest credential (Secure Document or Orb).
-
-<CodeGroup title="secureDocumentLegacy">
-```typescript title="JavaScript"
-import { IDKit, secureDocumentLegacy } from "@worldcoin/idkit-core";
-
-const request = await IDKit.request({
-  app_id: "app_xxxxx",
-  action: "my-action",
-  rp_context: { /* ... */ },
-}).preset(secureDocumentLegacy({ signal: "user-123" }));
-```
-
-```swift title="Swift"
-import IDKit
-
-let request = try IDKit.request(config: config)
-    .preset(secureDocumentLegacy(signal: "user-123"))
-```
-
-```kotlin title="Kotlin"
-import com.worldcoin.idkit.secureDocumentLegacy
-
-val request = IDKit.request(config)
-    .preset(secureDocumentLegacy(signal = "user-123"))
-```
-</CodeGroup>
-
-## `documentLegacy`
-
-Requires at least a Document verification. Returns the user's highest credential (Document, Secure Document, or Orb).
-
-<CodeGroup title="documentLegacy">
-```typescript title="JavaScript"
-import { IDKit, documentLegacy } from "@worldcoin/idkit-core";
-
-const request = await IDKit.request({
-  app_id: "app_xxxxx",
-  action: "my-action",
-  rp_context: { /* ... */ },
-}).preset(documentLegacy({ signal: "user-123" }));
-```
-
-```swift title="Swift"
-import IDKit
-
-let request = try IDKit.request(config: config)
-    .preset(documentLegacy(signal: "user-123"))
-```
-
-```kotlin title="Kotlin"
-import com.worldcoin.idkit.documentLegacy
-
-val request = IDKit.request(config)
-    .preset(documentLegacy(signal = "user-123"))
-```
-</CodeGroup>
-
-
-## `deviceLegacy`
-
-Requires at least a Device verification. Returns the user's highest credential (Device,Document, Secure Document, or Orb).
-
-<CodeGroup title="deviceLegacy">
-```typescript title="JavaScript"
-import { IDKit, deviceLegacy } from "@worldcoin/idkit-core";
-
-const request = await IDKit.request({
-  app_id: "app_xxxxx",
-  action: "my-action",
-  rp_context: { /* ... */ },
-}).preset(deviceLegacy({ signal: "user-123" }));
-```
-
-```swift title="Swift"
-import IDKit
-
-let request = try IDKit.request(config: config)
-    .preset(deviceLegacy(signal: "user-123"))
-```
-
-```kotlin title="Kotlin"
-import com.worldcoin.idkit.documentLegacy
-
-val request = IDKit.request(config)
-    .preset(deviceLegacy(signal = "user-123"))
-```
-</CodeGroup>
-
-## `selfieCheckLegacy` (Selfie Check Beta)
-
-Requires Selfie Check verification. Returns a World ID 3.0 Face proof.
-
-Learn more about Selfie Check here: [Selfie Check Overview](/world-id/selfie-check/overview).
-
-<CodeGroup title="selfieCheckLegacy">
+<CodeGroup title="Selfie Check">
 ```typescript title="JavaScript"
 import { IDKit, selfieCheckLegacy } from "@worldcoin/idkit-core";
 
+const preset = selfieCheckLegacy({ signal: "user-123" });
+
 const request = await IDKit.request({
   app_id: "app_xxxxx",
   action: "my-action",
-  rp_context: { /* ... */ },
-}).preset(selfieCheckLegacy({ signal: "user-123" }));
+  rp_context,
+  allow_legacy_proofs: true,
+}).preset(preset);
 ```
 
 ```tsx title="React"
 import { IDKitRequestWidget, selfieCheckLegacy } from "@worldcoin/idkit";
 
+const preset = selfieCheckLegacy({ signal: "user-123" });
+
 <IDKitRequestWidget
+  open={open}
+  onOpenChange={setOpen}
   app_id="app_xxxxx"
   action="my-action"
-  rp_context={rp_context}
-  preset={selfieCheckLegacy({ signal: "user-123" })}
+  rp_context={rpContext}
+  allow_legacy_proofs={true}
+  preset={preset}
+  handleVerify={handleVerify}
   onSuccess={(result) => { /* ... */ }}
 />;
 ```
+</CodeGroup>
 
-```swift title="Swift"
-import IDKit
+## Identity Check
 
-let request = try IDKit.request(config: config)
-    .preset(selfieCheckLegacy(signal: "user-123"))
+Identity Check is for attesting properties about a user from document-backed credentials. You can request attributes such as:
+
+| Attribute | Value type |
+| --- | --- |
+| `document_type` | `"passport"` or `"eid"` |
+| `document_number` | `string` |
+| `issuing_country` | ISO 3166-1 alpha-3 country code |
+| `full_name` | `string` |
+| `minimum_age` | `number` |
+| `nationality` | ISO 3166-1 alpha-3 country code |
+
+Set `require_proof_of_humanity: true` when the identity attestation should also require Proof of Human.
+
+<CodeGroup title="Identity Check">
+```typescript title="JavaScript"
+import { IDKit, identityCheck } from "@worldcoin/idkit-core";
+
+const preset = identityCheck({
+  attributes: [
+    { type: "document_type", value: "passport" },
+    { type: "minimum_age", value: 18 },
+  ],
+  require_proof_of_humanity: true,
+});
+
+const request = await IDKit.request({
+  app_id: "app_xxxxx",
+  action: "my-action",
+  rp_context,
+  allow_legacy_proofs: false,
+}).preset(preset);
 ```
 
-```kotlin title="Kotlin"
-import com.worldcoin.idkit.selfieCheckLegacy
+```tsx title="React"
+import { IDKitRequestWidget, identityCheck } from "@worldcoin/idkit";
 
-val request = IDKit.request(config)
-    .preset(selfieCheckLegacy(signal = "user-123"))
+const preset = identityCheck({
+  attributes: [
+    { type: "document_type", value: "passport" },
+    { type: "minimum_age", value: 18 },
+  ],
+  require_proof_of_humanity: true,
+});
+
+<IDKitRequestWidget
+  open={open}
+  onOpenChange={setOpen}
+  app_id="app_xxxxx"
+  action="my-action"
+  rp_context={rpContext}
+  allow_legacy_proofs={false}
+  preset={preset}
+  handleVerify={handleVerify}
+  onSuccess={(result) => { /* ... */ }}
+/>;
 ```
 </CodeGroup>
 
-## Parameters
+Successful Identity Check responses include `identity_attested` so your backend can distinguish whether the requested attributes matched.
 
-All legacy presets accept an optional `signal` parameter:
+## User presence and liveness
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `signal` | `string?` | Binds specific context into the proof (e.g. user ID, wallet address). Your backend should enforce the same value. |
+`require_user_presence` asks World App to perform an additional liveness step before completing the proof. This flag works with presets.
+
+<CodeGroup title="User presence">
+```typescript title="JavaScript"
+import { IDKit, proofOfHuman } from "@worldcoin/idkit-core";
+
+const preset = proofOfHuman({ signal: "user-123" });
+
+const request = await IDKit.request({
+  app_id: "app_xxxxx",
+  action: "my-action",
+  rp_context,
+  allow_legacy_proofs: true,
+  require_user_presence: true,
+}).preset(preset);
+```
+
+```tsx title="React"
+import { IDKitRequestWidget, proofOfHuman } from "@worldcoin/idkit";
+
+const preset = proofOfHuman({ signal: "user-123" });
+
+<IDKitRequestWidget
+  open={open}
+  onOpenChange={setOpen}
+  app_id="app_xxxxx"
+  action="my-action"
+  rp_context={rpContext}
+  allow_legacy_proofs={true}
+  require_user_presence={true}
+  preset={preset}
+  handleVerify={handleVerify}
+  onSuccess={(result) => { /* ... */ }}
+/>;
+```
+</CodeGroup>
+
+If the user does not complete the liveness step, the request fails with `user_presence_failed`.
+
+## Other legacy presets
+
+These presets only return World ID 3.0 proofs. Keep them for existing integrations or when you specifically need the older verification level.
+
+| Preset | What it requests |
+| --- | --- |
+| `orbLegacy` | Orb verification. |
+| `secureDocumentLegacy` | At least a Secure Document verification. Returns the user's highest legacy credential: Secure Document or Orb. |
+| `documentLegacy` | At least a Document verification. Returns the user's highest legacy credential: Document, Secure Document, or Orb. |
+| `deviceLegacy` | At least a Device verification. Returns the user's highest legacy credential: Device, Document, Secure Document, or Orb. |
+
+## Common parameters
+
+| Parameter | Where it is used | Description |
+| --- | --- | --- |
+| `signal` | Presets | Binds application context into the proof, such as a user ID or wallet address. Your backend should enforce the same value. |
+| `allow_legacy_proofs` | Request config and widgets | Required for request flows. Set to `true` while accepting World ID 3.0 fallback proofs; set to `false` for World ID 4.0-only requests. |
+| `require_user_presence` | Request config and widgets | Optional liveness step. Defaults to `false`. |

--- a/world-id/idkit/error-codes.mdx
+++ b/world-id/idkit/error-codes.mdx
@@ -129,6 +129,11 @@ This page focuses on IDKit SDK and bridge error codes returned during request fl
       <td className="p-2 align-middle">Request a fresh RP signature before starting verification.</td>
     </tr>
     <tr>
+      <td className="p-2 align-middle"><code>user_presence_failed</code></td>
+      <td className="p-2 align-middle">Required user-presence check was not completed.</td>
+      <td className="p-2 align-middle">Let the user retry the request.</td>
+    </tr>
+    <tr>
       <td className="p-2 align-middle"><code>identity_attributes_not_matched</code></td>
       <td className="p-2 align-middle">User identity attributes did not match the requested constraints.</td>
       <td className="p-2 align-middle">Show an eligibility fallback or adjust the requested attribute constraints.</td>


### PR DESCRIPTION
This PR ...

- Reworks the IDKit credentials page around product offerings and preset helpers.
- Adds preset-focused JavaScript and React examples using named `preset` constants.
- Documents Proof of Human, Passport, Selfie Check, user presence, and legacy presets.
- Adds `user_presence_failed` to the IDKit error-code reference.
- Points legacy integrations to the World ID 4.0 migration guide.