### PR TITLE
docs: add staging verifier contract address

### DIFF
--- a/world-id/idkit/onchain-verification.mdx
+++ b/world-id/idkit/onchain-verification.mdx
@@ -95,11 +95,12 @@ const unpackedProof = abi.decode(["uint256[8]"], proof)[0];
 ## 2. Verifying Uniqueness proofs in `WorldIDVerifier.sol` (World ID 4.0)
 
 `WorldIDVerifier` is deployed on World Chain Mainnet as an upgradeable proxy.
-Use the proxy address in your integration:
+Use the proxy address for your environment:
 
-| Chain | `WorldIDVerifier` proxy |
-|---|---|
-| World Chain | [0x00000000009E00F9FE82CfeeBB4556686da094d7](https://worldscan.org/address/0x00000000009E00F9FE82CfeeBB4556686da094d7) |
+| Environment | Chain | `WorldIDVerifier` proxy |
+|---|---|---|
+| Production | World Chain | [0x00000000009E00F9FE82CfeeBB4556686da094d7](https://worldscan.org/address/0x00000000009E00F9FE82CfeeBB4556686da094d7) |
+| Staging | World Chain | [0x703a6316c975DEabF30b637c155edD53e24657DB](https://worldscan.org/address/0x703a6316c975DEabF30b637c155edD53e24657DB) |
 
 For v4 uniqueness proofs, call `verify(...)` on the `WorldIDVerifier` proxy and
 store used nullifiers to enforce one-human-one-action semantics in your


### PR DESCRIPTION
This PR documents the staging `WorldIDVerifier` proxy from the [`world-id-protocol` staging deployment JSON](https://github.com/worldcoin/world-id-protocol/blob/e447e14f7196e224278a436d835923dc59308345/contracts/deployments/core/staging.json#L20).