### PR TITLE
docs: add idkit mini apps guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -65,6 +65,7 @@
               "world-id/idkit/integrate",
               "world-id/idkit/verification-flows",
               "world-id/idkit/credentials",
+              "world-id/idkit/mini-apps",
               "world-id/idkit/signatures",
               "world-id/idkit/build-with-llms",
               "world-id/idkit/onchain-verification",

--- a/mini-apps/commands/verify.mdx
+++ b/mini-apps/commands/verify.mdx
@@ -5,6 +5,6 @@ description: "World ID verification has moved to IDKit."
 "twitter:image": "https://raw.githubusercontent.com/worldcoin/developer-docs/main/images/docs/docs-meta.png"
 ---
 
-World ID has been unified into [IDKit](/world-id/idkit/integrate), so the same integration works in both mini apps and desktop.
+World ID has been unified into [IDKit](/world-id/idkit/mini-apps), so the same integration works in both mini apps and desktop.
 
-If you are migrating from MiniKit 1.x, replace `MiniKit.verify(...)` or `MiniKit.commandsAsync.verify(...)` with IDKit. See the [IDKit integration guide](/world-id/idkit/integrate) for setup instructions.
+If you are migrating from MiniKit 1.x, replace `MiniKit.verify(...)` or `MiniKit.commandsAsync.verify(...)` with IDKit. See [IDKit for Mini Apps](/world-id/idkit/mini-apps) for the Mini App integration shape, including Selfie Check.

--- a/mini-apps/migration/minikit-v2.mdx
+++ b/mini-apps/migration/minikit-v2.mdx
@@ -8,7 +8,7 @@ MiniKit 2.x consolidates command handling around async `MiniKit` methods and rem
 
 ## Breaking Changes
 
-- World ID verification moved out of MiniKit and into [`@worldcoin/idkit`](/world-id/idkit/integrate)
+- World ID verification moved out of MiniKit and into [`@worldcoin/idkit`](/world-id/idkit/mini-apps)
 - Commands moved to top-level async methods on `MiniKit` instead of `commandsAsync` and `commands`
 - Response interface changed to `{ executedWith, data }`
 - Types and helpers moved to `@worldcoin/minikit-js/commands`, `@worldcoin/minikit-js/siwe`, and `@worldcoin/minikit-js/address-book`
@@ -20,8 +20,7 @@ MiniKit 2.x consolidates command handling around async `MiniKit` methods and rem
 
 ## World ID Changes
 
-Any old `MiniKit.verify` or `MiniKit.commandsAsync.verify` flow should be replaced with IDKit. MiniKit 2.x only owns mini app commands.
-
+Any old `MiniKit.verify` or `MiniKit.commandsAsync.verify` flow should be replaced with IDKit. MiniKit 2.x only owns mini app commands. See [IDKit for Mini Apps](/world-id/idkit/mini-apps) for the current integration shape.
 
 ## Old To New
 

--- a/mini-apps/quick-start/commands.mdx
+++ b/mini-apps/quick-start/commands.mdx
@@ -9,7 +9,7 @@ Commands are async methods on `MiniKit`. Use `await MiniKit.<command>()` and han
 
 <Note>
   World ID verification is no longer a MiniKit command. Use
-  [`@worldcoin/idkit`](/world-id/idkit/integrate) for new verification flows.
+  [`@worldcoin/idkit`](/world-id/idkit/mini-apps) for new verification flows.
 </Note>
 
 Try our preview mini app to get a sense of how commands work. Scan the QR code below with your phone (you must have World App installed).

--- a/world-id/idkit/mini-apps.mdx
+++ b/world-id/idkit/mini-apps.mdx
@@ -1,0 +1,73 @@
+---
+title: "Mini Apps"
+description: "Use IDKit for World ID and Selfie Check verification inside Mini Apps."
+"og:image": "https://raw.githubusercontent.com/worldcoin/developer-docs/main/images/docs/docs-meta.png"
+"twitter:image": "https://raw.githubusercontent.com/worldcoin/developer-docs/main/images/docs/docs-meta.png"
+---
+
+{/* cspell:ignore idkit minikit rp_context app_id rp_id selfie sybil nullifier */}
+
+IDKit is the verification layer for Mini Apps. MiniKit handles native Mini App commands such as wallet auth, payments, transactions, sharing, and permissions. World ID verification, including Selfie Check, is implemented with `@worldcoin/idkit`.
+
+Inside World App, IDKit uses the native World App transport — no QR code is shown. The same widget also works outside World App, where it falls back to the normal connect URL and QR experience. Your backend responsibilities do not change: sign each request server-side, verify the proof server-side, and store nullifiers for replay protection.
+
+{/* TODO: upload demo video, then uncomment.
+<video className="m-auto" width="700" autoPlay muted loop playsInline>
+  <source src="/images/docs/world-id/idkit/mini-apps-demo.mp4" type="video/mp4" />
+</video>
+*/}
+
+<Note>
+  If you are migrating from MiniKit 1.x, replace `MiniKit.verify(...)` or
+  `MiniKit.commandsAsync.verify(...)` with IDKit. MiniKit 2.x does not proxy
+  verification requests.
+</Note>
+
+## How IDKit fits a Mini App
+
+The integration is the standard IDKit flow — follow the [Integrate IDKit](/world-id/idkit/integrate) guide for installation, the server-side RP signature endpoint, backend proof verification, and nullifier storage. Nothing in those steps changes for Mini Apps.
+
+The Mini-App-specific details:
+
+- **Separate app IDs.** If your Mini App and World ID integration use separate Developer Portal apps, MiniKit initialization uses the Mini App `app_id`, while IDKit uses the World ID `app_id`, `rp_id`, action, and signing key.
+- **No transport configuration needed.** IDKit detects World App and uses the native transport automatically.
+- **Standalone websites work too.** If your Mini App also runs as a regular website, the same widget handles browser users. For iOS install-continuation flows outside World App, see [invite-code mode](/world-id/idkit/verification-flows#with-invite-code-mode).
+
+## Choose a verification level
+
+| Goal | IDKit preset |
+| --- | --- |
+| Strong sybil resistance or one-human-one-action checks | `proofOfHuman` |
+| Lower-friction liveness or bot deterrence | `selfieCheckLegacy` |
+| Passport-backed checks | `passport` |
+
+Check out this [page](/world-id/idkit/credentials) to learn about the different World ID credentials and which preset to use for each.
+
+## Example
+
+This is the same widget from [Step 4 of the integration guide](/world-id/idkit/integrate#step-4-generate-the-connect-url-and-collect-proof), using the `proofOfHuman` preset:
+
+```tsx title="components/WorldIdGate.tsx"
+<IDKitRequestWidget
+  open={open}
+  onOpenChange={setOpen}
+  app_id={appId} // World ID app_id, not the Mini App app_id
+  action="claim-airdrop-2026"
+  rp_context={rpContext} // Signed by your backend, see the integration guide
+  allow_legacy_proofs={true}
+  preset={proofOfHuman({ signal: userId })}
+  handleVerify={verifyProofOnBackend}
+  onSuccess={() => {
+    // Unlock the protected Mini App experience here.
+  }}
+/>
+```
+
+Use a stable `signal` (user ID, wallet address, claim ID) to bind the proof to app-specific context, and [store the nullifier](/world-id/idkit/integrate#step-6-store-the-nullifier) in your backend to enforce uniqueness.
+
+## Related pages
+
+- [Integrate IDKit](/world-id/idkit/integrate)
+- [Configure Credentials](/world-id/idkit/credentials)
+- [React reference](/world-id/idkit/react)
+- [MiniKit commands](/mini-apps/quick-start/commands)

--- a/world-id/idkit/mini-apps.mdx
+++ b/world-id/idkit/mini-apps.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Mini Apps"
-description: "Use IDKit for World ID and Selfie Check verification inside Mini Apps."
 "og:image": "https://raw.githubusercontent.com/worldcoin/developer-docs/main/images/docs/docs-meta.png"
 "twitter:image": "https://raw.githubusercontent.com/worldcoin/developer-docs/main/images/docs/docs-meta.png"
 ---
@@ -11,17 +10,17 @@ IDKit is the verification layer for Mini Apps. MiniKit handles native Mini App c
 
 Inside World App, IDKit uses the native World App transport — no QR code is shown. The same widget also works outside World App, where it falls back to the normal connect URL and QR experience. Your backend responsibilities do not change: sign each request server-side, verify the proof server-side, and store nullifiers for replay protection.
 
-{/* TODO: upload demo video, then uncomment.
-<video className="m-auto" width="700" autoPlay muted loop playsInline>
-  <source src="/images/docs/world-id/idkit/mini-apps-demo.mp4" type="video/mp4" />
-</video>
-*/}
-
 <Note>
   If you are migrating from MiniKit 1.x, replace `MiniKit.verify(...)` or
   `MiniKit.commandsAsync.verify(...)` with IDKit. MiniKit 2.x does not proxy
   verification requests.
 </Note>
+
+<video className="m-auto" width="300" autoPlay muted loop playsInline>
+  <source src="/images/docs/mini-apps/commands/verify.mp4" type="video/mp4" />
+  Your browser does not support the video tag.
+</video>
+
 
 ## How IDKit fits a Mini App
 


### PR DESCRIPTION
This PR ...
- adds an IDKit Mini Apps guide for World ID and Selfie Check usage in Mini Apps
- wires the guide into the World ID navigation
- updates MiniKit verification migration links to point at the new guide