### PR TITLE
Fix Claude MCP setup command argument order

### DIFF
--- a/model-context-protocol/developer-portal.mdx
+++ b/model-context-protocol/developer-portal.mdx
@@ -33,12 +33,11 @@ Replace `api_...` with the API key you copied from the Developer Portal.
 <Tabs>
   <Tab title="Claude Code">
     ```bash
-    claude mcp add \
+    claude mcp add world-developer-portal \
+      https://developer.world.org/api/mcp \
       --transport http \
       --scope project \
-      --header "Authorization: Bearer api_..." \
-      world-developer-portal \
-      https://developer.world.org/api/mcp
+      --header "Authorization: Bearer api_..."
     ```
   </Tab>
   <Tab title="Codex">


### PR DESCRIPTION
Same bug as worldcoin/developer-portal#2080, in the Claude Code tab of the MCP setup page: the `claude` CLI's `--header` flag is variadic, so the server name and URL placed after it are consumed as extra header values and the command fails with `missing required argument 'name'`. This moves the positionals first.

The Codex, Cursor, and VS Code tabs are valid as-is. The SKILL.md copy of this command already has the correct order.

Generated with [Claude Code](https://claude.com/claude-code)