### PR TITLE
docs(world-id): add Sandbox environment guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -84,6 +84,13 @@
             ]
           },
           {
+            "group": "Sandbox",
+            "pages": [
+              "world-id/sandbox/what-is-sandbox",
+              "world-id/sandbox/sandbox-access"
+            ]
+          },
+          {
             "group": "Credentials",
             "pages": [
               "world-id/credentials/1",

--- a/world-id/sandbox/sandbox-access.mdx
+++ b/world-id/sandbox/sandbox-access.mdx
@@ -31,14 +31,12 @@ you to the external tester group directly.
 
 ### Android
 
-The sandbox build is available on **both** the Google Play testing track and Firebase
-App Distribution — use whichever you prefer.
+The sandbox build is distributed via **Firebase App Distribution**.
 
-1. Open the invite/download link we provide for your chosen channel.
+1. Open the invite/download link we provide.
 2. Follow the link to install the **World ID (Sandbox)** build.
 
-If you install via Firebase App Distribution, you may be prompted to install the App
-Tester helper the first time.
+You may be prompted to install the App Tester helper the first time.
 
 <Note>
 Contact your World point of contact to get the current Android links.

--- a/world-id/sandbox/sandbox-access.mdx
+++ b/world-id/sandbox/sandbox-access.mdx
@@ -67,4 +67,5 @@ Contact your World point of contact to get the current Android links.
 ## Next step
 
 Once you're installed and pointed at Sandbox, you're ready to run the Selfie Check
-integration flows. (Testing those flows is covered in a separate guide.)
+integration flows. See [Testing Selfie Check in Sandbox](/world-id/sandbox/testing-selfie-check)
+for coverage, critical user journeys, and known limitations.

--- a/world-id/sandbox/sandbox-access.mdx
+++ b/world-id/sandbox/sandbox-access.mdx
@@ -61,9 +61,3 @@ proof to your session over the bridge.
   integration validation only.
 - **Accounts are resettable.** You can delete and recreate accounts freely while
   testing.
-
-## Next step
-
-Once you're installed and pointed at Sandbox, you're ready to run the Selfie Check
-integration flows. See [Testing Selfie Check in Sandbox](/world-id/sandbox/testing-selfie-check)
-for coverage, critical user journeys, and known limitations.

--- a/world-id/sandbox/sandbox-access.mdx
+++ b/world-id/sandbox/sandbox-access.mdx
@@ -44,11 +44,11 @@ Contact your World point of contact to get the current Android links.
 
 ## 2. Point your integration at Sandbox
 
-1. **Update IDKit** to a version with Sandbox support.
-2. **Select Sandbox** as the destination for your verification requests, instead of
-   Production.
-3. Run a request from your surface — the handoff will open the sandbox World ID app and
-   return a proof to your session over the bridge.
+1. **Update IDKit** to the latest version.
+2. **Set `environment: sandbox`** in your IDKit configuration.
+
+Nothing else is required — the handoff will open the sandbox World ID app and return a
+proof to your session over the bridge.
 
 ## Things to know
 

--- a/world-id/sandbox/sandbox-access.mdx
+++ b/world-id/sandbox/sandbox-access.mdx
@@ -1,0 +1,70 @@
+---
+title: "How to get access"
+description: "Install the sandbox World ID app and point your integration at the Sandbox environment."
+"og:image": "https://raw.githubusercontent.com/worldcoin/developer-docs/main/images/docs/docs-meta.png"
+"twitter:image": "https://raw.githubusercontent.com/worldcoin/developer-docs/main/images/docs/docs-meta.png"
+---
+
+{/* cspell:ignore idkit TestFlight VZEurhHe Eurh */}
+
+Getting set up in Sandbox has two parts: install the **sandbox World ID app** on your
+test device, and point your **integration** at the Sandbox environment. Both are
+covered below.
+
+New here? Start with [What is Sandbox?](/world-id/sandbox/what-is-sandbox) for context.
+
+## 1. Install the sandbox World ID app
+
+The sandbox builds are not published to the App Store or Google Play. You install them
+directly using the links below.
+
+### iOS — TestFlight
+
+1. Install [TestFlight](https://apps.apple.com/app/testflight/id899247664) from the
+   App Store if you don't have it.
+2. Open the public TestFlight link to join the external tester group:
+   [testflight.apple.com/join/VZEurhHe](https://testflight.apple.com/join/VZEurhHe)
+3. Install the **World ID (Sandbox)** build from TestFlight.
+
+No App Store Connect account or per-email invite is required — the public link admits
+you to the external tester group directly.
+
+### Android
+
+The sandbox build is available on **both** the Google Play testing track and Firebase
+App Distribution — use whichever you prefer.
+
+1. Open the invite/download link we provide for your chosen channel.
+2. Follow the link to install the **World ID (Sandbox)** build.
+
+If you install via Firebase App Distribution, you may be prompted to install the App
+Tester helper the first time.
+
+<Note>
+Contact your World point of contact to get the current Android links.
+</Note>
+
+## 2. Point your integration at Sandbox
+
+1. **Update IDKit** to a version with Sandbox support.
+2. **Select Sandbox** as the destination for your verification requests, instead of
+   Production.
+3. Run a request from your surface — the handoff will open the sandbox World ID app and
+   return a proof to your session over the bridge.
+
+## Things to know
+
+- **Sandbox apps aren't in the app stores.** Because the builds are distributed
+  directly to testers, install/store deep links won't route to a store listing the way
+  they do in production. Testers install via TestFlight (iOS) or the Android link
+  instead — so any journey that depends on a real store install can't be exercised
+  exactly as it will be in production.
+- **Proofs are non-production.** Identities and proofs issued in Sandbox are for
+  integration validation only.
+- **Accounts are resettable.** You can delete and recreate accounts freely while
+  testing.
+
+## Next step
+
+Once you're installed and pointed at Sandbox, you're ready to run the Selfie Check
+integration flows. (Testing those flows is covered in a separate guide.)

--- a/world-id/sandbox/what-is-sandbox.mdx
+++ b/world-id/sandbox/what-is-sandbox.mdx
@@ -1,0 +1,54 @@
+---
+title: "What is Sandbox?"
+description: "An isolated, production-like environment for testing your World ID integration end-to-end."
+"og:image": "https://raw.githubusercontent.com/worldcoin/developer-docs/main/images/docs/docs-meta.png"
+"twitter:image": "https://raw.githubusercontent.com/worldcoin/developer-docs/main/images/docs/docs-meta.png"
+---
+
+{/* cspell:ignore idkit TestFlight */}
+
+Sandbox is a dedicated, production-like environment for building and testing your
+World ID integration. It runs alongside Production as its own environment, with its
+own backend and its own builds of the World ID app for iOS and Android.
+
+It lets you run a complete integration — from your app or website, through IDKit, into
+the World ID app, and back — without touching production identities or issuing real
+proofs.
+
+## Why use Sandbox
+
+Sandbox is built for integration testing. It gives you:
+
+- **A full end-to-end round trip.** Sandbox is a valid IDKit destination, so you can
+  drive a real request from your surface into the World ID app and receive a proof
+  back over the bridge — the same path your production integration will use.
+- **Resettable accounts.** Delete an account and sign up again as often as you need.
+- **Simulated verification.** Exercise verification flows without real hardware or
+  real-world credentials.
+- **Controllable gating.** You decide whether the system enforces fraud, risk, and
+  attestation checks. Turn enforcement off to move quickly through integration testing,
+  or turn it on to validate how your integration behaves under production-like gating.
+
+## What you can test
+
+The full relying-party journey from your surface into the World ID app and back:
+request handoff, consent, capture, enrollment and matching, proof generation, and
+delivery of the proof to your session.
+
+Both same-device (deep link) and cross-device (QR) flows are supported, on both iOS
+and Android sandbox builds.
+
+## What Sandbox is not
+
+- **Not production.** Accounts and proofs issued in Sandbox are for integration
+  validation only — not load testing, security certification, or production sign-off.
+- **Not a source of real uniqueness.** Sandbox does not represent real-world identity
+  or uniqueness at scale.
+- **Not published to the app stores.** The sandbox World ID builds are distributed
+  directly to testers rather than through the App Store or Google Play. See
+  [How to get access](/world-id/sandbox/sandbox-access) for how to install them.
+
+## Next step
+
+Ready to try it? Head to [How to get access](/world-id/sandbox/sandbox-access) to
+install the sandbox app and point your integration at Sandbox.


### PR DESCRIPTION
## Summary
- Adds a new "Sandbox" section under World ID: `What is Sandbox?` and `How to get access`, covering the new production-like testing environment (own backend, own iOS/Android World ID builds, resettable accounts, valid IDKit destination).
- Registers the pages under a new `Sandbox` group in `docs.json`, between IDKit and Credentials.

## Why draft
Sandbox is still mid-rollout (Milestone 1 eng work targeted for 2026-07-21, Reddit e2e handoff targeted for 2026-07-31, and the live e2e round-trip test is currently blocked). Opening as a draft so it's reviewable now without implying the environment is ready for external developers to use today. Please confirm Milestone 1 status before marking ready for review / merging.

## Content notes
- iOS distribution via the public TestFlight link (`testflight.apple.com/join/VZEurhHe`) is confirmed settled — used as the primary install path.
- Android access is intentionally left as "contact your World point of contact," since the specific distribution channel/links aren't finalized yet.

## Test plan
- [x] `npx cspell world-id/sandbox/*.mdx` passes
- [x] `docs.json` validated as well-formed JSON
- [ ] Confirm Sandbox rollout status (Milestone 1) before merging
- [ ] Verify Android access instructions once that channel is finalized

🤖 Generated with [Claude Code](https://claude.com/claude-code)