### PR TITLE
fix: serve distinct OpenAPI specs in llms.txt

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -116,7 +116,10 @@
                 "pages": [
                   {
                     "group": "Indexer",
-                    "openapi": "https://indexer.us.id-infra.worldcoin.dev/openapi.json",
+                    "openapi": {
+                      "source": "https://indexer.us.id-infra.worldcoin.dev/openapi.json",
+                      "directory": "api-reference/indexer"
+                    },
                     "pages": [
                       "POST /inclusion-proof",
                       "POST /packed-account",
@@ -126,7 +129,10 @@
                   },
                   {
                     "group": "Gateway",
-                    "openapi": "https://gateway.id-infra.worldcoin.dev/openapi.json",
+                    "openapi": {
+                      "source": "https://gateway.id-infra.worldcoin.dev/openapi.json",
+                      "directory": "api-reference/gateway"
+                    },
                     "pages": [
                       "POST /create-account",
                       "POST /insert-authenticator",


### PR DESCRIPTION
## Summary

- give the Indexer and Gateway OpenAPI sources distinct Mintlify directories
- preserve both live remote specifications instead of copying snapshots into this repository
- make the generated OpenAPI entries resolve to separate same-origin assets

## Why

Both remote specifications are named `openapi.json`. Without explicit directories, the generated `llms.txt` collapses them into `/api-reference/openapi.json`, which currently returns `404`.

Closes #81.

## Validation

- verified all 11 configured operations against the live Indexer and Gateway specifications
- `pnpm exec cspell "**/*.{md,mdx,json,yml,yaml,ts,tsx,js,jsx}" --no-progress` — 134 files, 0 issues
- `mint dev` — representative Indexer and Gateway API pages return `200` and render from their original remote sources
- `mint validate` — no new warning; retains the two existing snippet import warnings
- `mint broken-links` — unchanged from the existing 108-link / 48-file baseline
