### PR TITLE
 Fix: v4 `action` mapping must be reduced to a field element

### DIFF
--- a/world-id/idkit/onchain-verification.mdx
+++ b/world-id/idkit/onchain-verification.mdx
@@ -165,7 +165,7 @@ contract VerifyUniquenessV4 {
 
 Minimal mapping from IDKit result:
 - `nullifier` = `responses[i].nullifier`
-- `action` = `keccak256(action)` as `uint256`
+- `action` = `hashToField(action)`, i.e. `uint256(keccak256(action)) >> 8`
 - `rpId` = numeric form of your `rp_context.rp_id` (the `rp_`-prefixed string from your RP context, not the result)
 - `nonce` = top-level `nonce`
 - `signalHash` = `responses[i].signal_hash`


### PR DESCRIPTION
## Fix: v4 `action` mapping must be reduced to a field element

**File:** `world-id/idkit/onchain-verification.mdx` (line 168)

The "Minimal mapping from IDKit result" list in section 2 (World ID 4.0) says:

> `action` = `keccak256(action)` as `uint256`

Following this literally makes `WorldIDVerifier.verify(...)` revert with
`InvalidAction()` (`0x4a7f394f`).

`action` is a circuit public input, so it must be a BN254 field element
(modulus ≈ 2.188e76). A raw `keccak256` is a full 256-bit value and frequently
exceeds it. For the action string `"world-demo-v2"`:

keccak256("world-demo-v2") = 26010334832445723922903112885823480789134808060722738567577694943080833342878
                           ≈ 2.601e76   → above the modulus → InvalidAction()

▎ ▎ 8                       = 101602870439241109073840284710247971832557843987198197529600370871409505245
▎ ▎                        → verifies

Verified against both live proxies on World Chain:

| `action` value | `0x000000...94d7` (prod) | `0x703a63...57DB` (staging) |
| --- | --- | --- |
| `keccak256(action)` (as documented) | `InvalidAction()` | `InvalidAction()` |
| `keccak256(action) >> 8` | verifies | verifies |

`>> 8` is the standard `hashToField` reduction already used throughout World ID —
including the v3 example higher up on this same page, which correctly calls
`abi.encodePacked(signal).hashToField()`. So the page is currently inconsistent
with itself: the v3 section reduces to the field, the v4 mapping list does not.

Worth fixing because the failure mode is unhelpful: every other parameter maps
exactly as documented, so you get a well-formed call that reverts naming the one
field you copied verbatim from the docs, with no hint that it needs reducing.