### PR TITLE
docs(world-chain): add third-party benchmarks section

### DIFF
--- a/world-chain/providers/nodes.mdx
+++ b/world-chain/providers/nodes.mdx
@@ -45,3 +45,7 @@ QuickNode offers several benefits for developers building on World Chain, read m
 
 - World Chain
 - World Chain Sepolia
+
+## Independent benchmark
+
+For an independent latency and reliability comparison of public World Chain RPC endpoints, see the [OpenChainBench World Chain RPC benchmark](https://openchainbench.com/benchmarks/world-chain-rpc). It covers a set of community providers, with latency (p50/p90/p99) and success rate probed every 60 seconds from three regions and published under CC BY 4.0 alongside the open-source harness.

--- a/world-chain/resources.mdx
+++ b/world-chain/resources.mdx
@@ -9,10 +9,6 @@ title: "Resources"
 - [World Chain Mainnet Status](https://worldchain-mainnet-status.alchemy.com/)
 - [World Chain Sepolia Status](https://worldchain-sepolia-status.alchemy.com/)
 
-## Third-Party Benchmarks
-
-- [OpenChainBench World Chain RPC latency](https://openchainbench.com/benchmarks/world-chain-rpc) — independent open-source benchmark measuring public World Chain RPC endpoint latency every minute from three regions. Data published under CC BY 4.0.
-
 ## Documentation
 
 - [Brand Kit](https://world.org/press)

--- a/world-chain/resources.mdx
+++ b/world-chain/resources.mdx
@@ -9,6 +9,10 @@ title: "Resources"
 - [World Chain Mainnet Status](https://worldchain-mainnet-status.alchemy.com/)
 - [World Chain Sepolia Status](https://worldchain-sepolia-status.alchemy.com/)
 
+## Third-Party Benchmarks
+
+- [OpenChainBench World Chain RPC latency](https://openchainbench.com/benchmarks/world-chain-rpc) — independent open-source benchmark measuring public World Chain RPC endpoint latency every minute from three regions. Data published under CC BY 4.0.
+
 ## Documentation
 
 - [Brand Kit](https://world.org/press)


### PR DESCRIPTION
Adds a short "Third-Party Benchmarks" section to `world-chain/resources.mdx`, between the existing "Status Links" and "Documentation" sections.

**Why this fits:**
- The Resources page already lists external status monitoring (Alchemy status pages)
- OpenChainBench provides independent public RPC latency measurements for World Chain
- Developers evaluating World Chain endpoints benefit from a neutral third-party performance reference

**What's added:**
- One new H2 section with a single bullet
- Link to https://openchainbench.com/benchmarks/world-chain-rpc

**About OpenChainBench:** independent open-source project measuring public RPC endpoint latency across 22+ chains every minute from three regions (US East, EU West, Singapore). Data published under CC BY 4.0, Go harness open sourced on GitHub, no affiliation with any RPC provider.

**Disclosure:** I contribute to OpenChainBench. Happy to reword or drop entirely if this doesn't fit editorial guidelines.