### PR TITLE
href "Developer Portal" to developer.world.org

### DIFF
--- a/world-id/sandbox/sandbox-access.mdx
+++ b/world-id/sandbox/sandbox-access.mdx
@@ -33,7 +33,8 @@ you to the external tester group directly.
 
 The sandbox build is distributed through a **private testing track on Google Play**.
 
-1. In the Developer Portal, select **World ID Sandbox** from the sidebar.
+1. In the [Developer Portal](https://developer.world.org), select **World ID Sandbox**
+   from the sidebar.
 2. Enter the email address associated with your Google Play account to request tester
    access.
 3. Once access is granted, scan the QR code or open the Google Play link on the same


### PR DESCRIPTION
## Why
Prevent confusion amongst testers that may have staging-developer.world.org in hand and are requesting access from there instead of the prod developer.world.org
