### PR TITLE
fix(docs): link credential cards to credential pages

### DIFF
--- a/world-id/overview.mdx
+++ b/world-id/overview.mdx
@@ -41,19 +41,19 @@ Through credentials like Proof of Human, Document and Selfie Check, World ID ext
   <div className="grid gap-4 md:grid-cols-3">
     <a href="/world-id/credentials/1" className="block overflow-hidden rounded-[12px] border border-zinc-200 bg-white no-underline shadow-[0_1px_0_rgba(0,0,0,0.03)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_10px_26px_rgba(15,23,42,0.08)] dark:border-zinc-700 dark:bg-zinc-900 dark:shadow-none dark:hover:border-zinc-600 dark:hover:shadow-[0_10px_24px_rgba(2,6,23,0.32)]">
       <div className="flex items-center justify-center bg-white dark:bg-zinc-900" style={{ height: 120 }}>
-        <img src="/images/docs/verification-badge.svg" alt="Proof of Human" style={{ height: 72, width: 72, objectFit: 'contain' }} />
+        <img noZoom src="/images/docs/verification-badge.svg" alt="Proof of Human" style={{ height: 72, width: 72, objectFit: 'contain' }} />
       </div>
       <div className="p-4"><h3 className="m-0 text-base font-semibold text-zinc-900 dark:text-zinc-100">Proof of Human</h3><p className="mt-2 text-sm text-zinc-600 dark:text-zinc-300">Highest-assurance uniqueness signal from Orb verification. Best for one-person-one-action flows and strongest Sybil resistance.</p></div>
     </a>
     <a href="/world-id/credentials/9303" className="block overflow-hidden rounded-[12px] border border-zinc-200 bg-white no-underline shadow-[0_1px_0_rgba(0,0,0,0.03)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_10px_26px_rgba(15,23,42,0.08)] dark:border-zinc-700 dark:bg-zinc-900 dark:shadow-none dark:hover:border-zinc-600 dark:hover:shadow-[0_10px_24px_rgba(2,6,23,0.32)]">
       <div className="flex items-center justify-center bg-white dark:bg-zinc-900" style={{ height: 120 }}>
-        <img src="/images/docs/passport.png" alt="Document" style={{ width: 72, objectFit: 'contain' }} />
+        <img noZoom src="/images/docs/passport.png" alt="Document" style={{ width: 72, objectFit: 'contain' }} />
       </div>
       <div className="p-4"><h3 className="m-0 text-base font-semibold text-zinc-900 dark:text-zinc-100">Document</h3><p className="mt-2 text-sm text-zinc-600 dark:text-zinc-300">Proves possession of a unique government document through NFC checks. Useful for fast proof of age and document-backed access flows.</p></div>
     </a>
     <a href="/world-id/credentials/11" className="block overflow-hidden rounded-[12px] border border-zinc-200 bg-white no-underline shadow-[0_1px_0_rgba(0,0,0,0.03)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_10px_26px_rgba(15,23,42,0.08)] dark:border-zinc-700 dark:bg-zinc-900 dark:shadow-none dark:hover:border-zinc-600 dark:hover:shadow-[0_10px_24px_rgba(2,6,23,0.32)]">
       <div className="flex items-center justify-center bg-white dark:bg-zinc-900" style={{ height: 120 }}>
-        <img src="/images/docs/selfie-check.png" alt="Selfie Check" style={{ height: 72, width: 72, objectFit: 'contain' }} />
+        <img noZoom src="/images/docs/selfie-check.png" alt="Selfie Check" style={{ height: 72, width: 72, objectFit: 'contain' }} />
       </div>
       <div className="p-4"><h3 className="m-0 flex items-center gap-2 text-base font-semibold text-zinc-900 dark:text-zinc-100">Selfie Check <div className="method-pill rounded-lg bg-blue-400/20 px-1.5 py-0.5 text-sm leading-5 font-semibold text-blue-700 dark:bg-blue-400/20 dark:text-blue-300">Beta</div></h3><p className="mt-2 text-sm text-zinc-600 dark:text-zinc-300">Low-friction, medium-assurance liveness and uniqueness signal from a selfie flow. Best for sign-up and bot defense where speed matters most.</p></div>
     </a>

--- a/world-id/overview.mdx
+++ b/world-id/overview.mdx
@@ -39,24 +39,24 @@ Through credentials like Proof of Human, Document and Selfie Check, World ID ext
 
 <div className="not-prose mt-5">
   <div className="grid gap-4 md:grid-cols-3">
-    <div className="overflow-hidden rounded-[12px] border border-zinc-200 bg-white shadow-[0_1px_0_rgba(0,0,0,0.03)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_10px_26px_rgba(15,23,42,0.08)] dark:border-zinc-700 dark:bg-zinc-900 dark:shadow-none dark:hover:border-zinc-600 dark:hover:shadow-[0_10px_24px_rgba(2,6,23,0.32)]">
+    <a href="/world-id/credentials/1" className="block overflow-hidden rounded-[12px] border border-zinc-200 bg-white no-underline shadow-[0_1px_0_rgba(0,0,0,0.03)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_10px_26px_rgba(15,23,42,0.08)] dark:border-zinc-700 dark:bg-zinc-900 dark:shadow-none dark:hover:border-zinc-600 dark:hover:shadow-[0_10px_24px_rgba(2,6,23,0.32)]">
       <div className="flex items-center justify-center bg-white dark:bg-zinc-900" style={{ height: 120 }}>
         <img src="/images/docs/verification-badge.svg" alt="Proof of Human" style={{ height: 72, width: 72, objectFit: 'contain' }} />
       </div>
       <div className="p-4"><h3 className="m-0 text-base font-semibold text-zinc-900 dark:text-zinc-100">Proof of Human</h3><p className="mt-2 text-sm text-zinc-600 dark:text-zinc-300">Highest-assurance uniqueness signal from Orb verification. Best for one-person-one-action flows and strongest Sybil resistance.</p></div>
-    </div>
-    <div className="overflow-hidden rounded-[12px] border border-zinc-200 bg-white shadow-[0_1px_0_rgba(0,0,0,0.03)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_10px_26px_rgba(15,23,42,0.08)] dark:border-zinc-700 dark:bg-zinc-900 dark:shadow-none dark:hover:border-zinc-600 dark:hover:shadow-[0_10px_24px_rgba(2,6,23,0.32)]">
+    </a>
+    <a href="/world-id/credentials/9303" className="block overflow-hidden rounded-[12px] border border-zinc-200 bg-white no-underline shadow-[0_1px_0_rgba(0,0,0,0.03)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_10px_26px_rgba(15,23,42,0.08)] dark:border-zinc-700 dark:bg-zinc-900 dark:shadow-none dark:hover:border-zinc-600 dark:hover:shadow-[0_10px_24px_rgba(2,6,23,0.32)]">
       <div className="flex items-center justify-center bg-white dark:bg-zinc-900" style={{ height: 120 }}>
         <img src="/images/docs/passport.png" alt="Document" style={{ width: 72, objectFit: 'contain' }} />
       </div>
       <div className="p-4"><h3 className="m-0 text-base font-semibold text-zinc-900 dark:text-zinc-100">Document</h3><p className="mt-2 text-sm text-zinc-600 dark:text-zinc-300">Proves possession of a unique government document through NFC checks. Useful for fast proof of age and document-backed access flows.</p></div>
-    </div>
-    <div className="overflow-hidden rounded-[12px] border border-zinc-200 bg-white shadow-[0_1px_0_rgba(0,0,0,0.03)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_10px_26px_rgba(15,23,42,0.08)] dark:border-zinc-700 dark:bg-zinc-900 dark:shadow-none dark:hover:border-zinc-600 dark:hover:shadow-[0_10px_24px_rgba(2,6,23,0.32)]">
+    </a>
+    <a href="/world-id/credentials/11" className="block overflow-hidden rounded-[12px] border border-zinc-200 bg-white no-underline shadow-[0_1px_0_rgba(0,0,0,0.03)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_10px_26px_rgba(15,23,42,0.08)] dark:border-zinc-700 dark:bg-zinc-900 dark:shadow-none dark:hover:border-zinc-600 dark:hover:shadow-[0_10px_24px_rgba(2,6,23,0.32)]">
       <div className="flex items-center justify-center bg-white dark:bg-zinc-900" style={{ height: 120 }}>
         <img src="/images/docs/selfie-check.png" alt="Selfie Check" style={{ height: 72, width: 72, objectFit: 'contain' }} />
       </div>
       <div className="p-4"><h3 className="m-0 flex items-center gap-2 text-base font-semibold text-zinc-900 dark:text-zinc-100">Selfie Check <div className="method-pill rounded-lg bg-blue-400/20 px-1.5 py-0.5 text-sm leading-5 font-semibold text-blue-700 dark:bg-blue-400/20 dark:text-blue-300">Beta</div></h3><p className="mt-2 text-sm text-zinc-600 dark:text-zinc-300">Low-friction, medium-assurance liveness and uniqueness signal from a selfie flow. Best for sign-up and bot defense where speed matters most.</p></div>
-    </div>
+    </a>
   </div>
 </div>
 


### PR DESCRIPTION
This PR fixes the credential cards on the World ID overview page.

- Links Proof of Human, Document, and Selfie Check cards to their credential pages
- Explicitly disables Mintlify image zoom for all three card images
- Preserves the existing card layout and hover styling

Validation:

- `pnpm check-links`
- `pnpm exec cspell world-id/overview.mdx --no-progress`
- `git diff --check`
- Mintlify transform check confirms three `noZoom` images and zero zoom-enabled `OptimizedImage` references
- Deployed Mintlify preview renders each image directly inside its credential link
