### PR TITLE
fix(world-chain): refresh deployed contract addresses

### DIFF
--- a/world-chain/developers/world-chain-contracts.mdx
+++ b/world-chain/developers/world-chain-contracts.mdx
@@ -89,7 +89,7 @@ title: "World Chain Contracts"
   <tbody>
     <tr>
       <td className="p-2 align-middle">AnchorStateRegistryProxy</td>
-      <td className="p-2 align-middle">[`0xD4D7A57DCC563756DeD99e224E144A6Bf0327099`](https://etherscan.io/address/0xD4D7A57DCC563756DeD99e224E144A6Bf0327099)</td>
+      <td className="p-2 align-middle">[`0x90BB48fe3310499Db36437dCAE642F721e32d094`](https://etherscan.io/address/0x90BB48fe3310499Db36437dCAE642F721e32d094)</td>
     </tr>
     <tr>
       <td className="p-2 align-middle">Batch Submitter</td>

--- a/world-chain/developers/world-chain-contracts.mdx
+++ b/world-chain/developers/world-chain-contracts.mdx
@@ -101,7 +101,7 @@ title: "World Chain Contracts"
     </tr>
     <tr>
       <td className="p-2 align-middle">DelayedWETHProxy</td>
-      <td className="p-2 align-middle">[`0xF9adF7c9502C5C60352C20a4d22683422DbD061F`](https://etherscan.io/address/0xF9adF7c9502C5C60352C20a4d22683422DbD061F)</td>
+      <td className="p-2 align-middle">[`0x19f4eF9dDE39a50a2EF948B7d55AA19F60d99498`](https://etherscan.io/address/0x19f4eF9dDE39a50a2EF948B7d55AA19F60d99498)</td>
     </tr>
     <tr>
       <td className="p-2 align-middle">DisputeGameFactoryProxy</td>
@@ -120,12 +120,12 @@ title: "World Chain Contracts"
       <td className="p-2 align-middle">[`0x470458C91978D2d929704489Ad730DC3E3001113`](https://etherscan.io/address/0x470458C91978D2d929704489Ad730DC3E3001113)</td>
     </tr>
     <tr>
-      <td className="p-2 align-middle">L2OutputOracleProxy</td>
+      <td className="p-2 align-middle">L2OutputOracleProxy (legacy)</td>
       <td className="p-2 align-middle">[`0x19A6d1E9034596196295CF148509796978343c5D`](https://etherscan.io/address/0x19A6d1E9034596196295CF148509796978343c5D)</td>
     </tr>
     <tr>
       <td className="p-2 align-middle">MIPS</td>
-      <td className="p-2 align-middle">[`0x16e83cE5Ce29BF90AD9Da06D2fE6a15d5f344ce4`](https://etherscan.io/address/0x16e83cE5Ce29BF90AD9Da06D2fE6a15d5f344ce4)</td>
+      <td className="p-2 align-middle">[`0xaCc005DCd857B401e4732E6F7837135A22825cfA`](https://etherscan.io/address/0xaCc005DCd857B401e4732E6F7837135A22825cfA)</td>
     </tr>
     <tr>
       <td className="p-2 align-middle">OptimismMintableERC20FactoryProxy</td>
@@ -137,11 +137,11 @@ title: "World Chain Contracts"
     </tr>
     <tr>
       <td className="p-2 align-middle">PermissionedDisputeGame</td>
-      <td className="p-2 align-middle">[`0x48cf980849a7eEA03180f7dea4E21C112097b03E`](https://etherscan.io/address/0x48cf980849a7eEA03180f7dea4E21C112097b03E)</td>
+      <td className="p-2 align-middle">[`0xe1dFFCBE4e22B813F26d2106D943C102e7cAb87e`](https://etherscan.io/address/0xe1dFFCBE4e22B813F26d2106D943C102e7cAb87e)</td>
     </tr>
     <tr>
       <td className="p-2 align-middle">PreimageOracle</td>
-      <td className="p-2 align-middle">[`0x9c065e11870B891D214Bc2Da7EF1f9DDFA1BE277`](https://etherscan.io/address/0x9c065e11870B891D214Bc2Da7EF1f9DDFA1BE277)</td>
+      <td className="p-2 align-middle">[`0x1E1d73536A081Ef2F355d29794547a9770Aeb1E0`](https://etherscan.io/address/0x1E1d73536A081Ef2F355d29794547a9770Aeb1E0)</td>
     </tr>
    <tr>
       <td className="p-2 align-middle">ProtocolVersionsProxy</td>
@@ -257,7 +257,7 @@ title: "World Chain Contracts"
   <tbody>
     <tr>
       <td className="p-2 align-middle">AnchorStateRegistryProxy</td>
-      <td className="p-2 align-middle">[`0x1333d5E5201D760444A399E77b3D337eBDB0DD07`](https://sepolia.etherscan.io/address/0x1333d5E5201D760444A399E77b3D337eBDB0DD07)</td>
+      <td className="p-2 align-middle">[`0xcC59030b952CE2c888f7Fc15f99E34c72cC6ca21`](https://sepolia.etherscan.io/address/0xcC59030b952CE2c888f7Fc15f99E34c72cC6ca21)</td>
     </tr>
     <tr>
       <td className="p-2 align-middle">Batch Submitter</td>
@@ -269,7 +269,7 @@ title: "World Chain Contracts"
     </tr>
     <tr>
       <td className="p-2 align-middle">DelayedWETHProxy</td>
-      <td className="p-2 align-middle">[`0x4F4B8Adf1af4b61bb62F68b7aF1c37f8A6311663`](https://sepolia.etherscan.io/address/0x4F4B8Adf1af4b61bb62F68b7aF1c37f8A6311663)</td>
+      <td className="p-2 align-middle">[`0x5706FB7D51a5c75cafaED0506d5a8e8ade1D83f7`](https://sepolia.etherscan.io/address/0x5706FB7D51a5c75cafaED0506d5a8e8ade1D83f7)</td>
     </tr>
     <tr>
       <td className="p-2 align-middle">DisputeGameFactoryProxy</td>
@@ -288,12 +288,12 @@ title: "World Chain Contracts"
       <td className="p-2 align-middle">[`0xd7DF54b3989855eb66497301a4aAEc33Dbb3F8DE`](https://sepolia.etherscan.io/address/0xd7DF54b3989855eb66497301a4aAEc33Dbb3F8DE)</td>
     </tr>
     <tr>
-      <td className="p-2 align-middle">L2OutputOracleProxy</td>
+      <td className="p-2 align-middle">L2OutputOracleProxy (legacy)</td>
       <td className="p-2 align-middle">[`0xc8886f8BAb6Eaeb215aDB5f1c686BF699248300e`](https://sepolia.etherscan.io/address/0xc8886f8BAb6Eaeb215aDB5f1c686BF699248300e)</td>
     </tr>
     <tr>
       <td className="p-2 align-middle">MIPS</td>
-      <td className="p-2 align-middle">[`0x69470D6970Cd2A006b84B1d4d70179c892cFCE01`](https://sepolia.etherscan.io/address/0x69470D6970Cd2A006b84B1d4d70179c892cFCE01)</td>
+      <td className="p-2 align-middle">[`0xaCc005DCd857B401e4732E6F7837135A22825cfA`](https://sepolia.etherscan.io/address/0xaCc005DCd857B401e4732E6F7837135A22825cfA)</td>
     </tr>
     <tr>
       <td className="p-2 align-middle">OptimismMintableERC20FactoryProxy</td>
@@ -305,11 +305,11 @@ title: "World Chain Contracts"
     </tr>
     <tr>
       <td className="p-2 align-middle">PermissionedDisputeGame</td>
-      <td className="p-2 align-middle">[`0x552334Bf0B124bD89BFF744f33Ca7e49d44a80Ac`](https://sepolia.etherscan.io/address/0x552334Bf0B124bD89BFF744f33Ca7e49d44a80Ac)</td>
+      <td className="p-2 align-middle">[`0xe1dFFCBE4e22B813F26d2106D943C102e7cAb87e`](https://sepolia.etherscan.io/address/0xe1dFFCBE4e22B813F26d2106D943C102e7cAb87e)</td>
     </tr>
     <tr>
       <td className="p-2 align-middle">PreimageOracle</td>
-      <td className="p-2 align-middle">[`0x92240135b46fc1142dA181f550aE8f595B858854`](https://sepolia.etherscan.io/address/0x92240135b46fc1142dA181f550aE8f595B858854)</td>
+      <td className="p-2 align-middle">[`0x1E1d73536A081Ef2F355d29794547a9770Aeb1E0`](https://sepolia.etherscan.io/address/0x1E1d73536A081Ef2F355d29794547a9770Aeb1E0)</td>
     </tr>
    <tr>
       <td className="p-2 align-middle">ProtocolVersionsProxy</td>


### PR DESCRIPTION
Refresh the documented World Chain contract addresses using the current live contract wiring on Ethereum mainnet and Sepolia.

- Update the AnchorStateRegistry proxies
- Update the active DelayedWETH, MIPS, PermissionedDisputeGame, and PreimageOracle addresses
- Mark the superseded L2OutputOracle deployments as legacy
- Keep the existing DisputeGameFactory addresses, verified through `AnchorStateRegistry.disputeGameFactory()`

The dispute-game addresses were derived from the active factory configuration and game getters:

- `DisputeGameFactory.gameImpls(respectedGameType)`
- `game.anchorStateRegistry()`
- `game.weth()`
- `game.vm()`
- `MIPS.oracle()`
