### PR TITLE
docs(sandbox): update iOS access to the App Store Connect enrollment flow

### DIFF
--- a/world-id/sandbox/sandbox-access.mdx
+++ b/world-id/sandbox/sandbox-access.mdx
@@ -5,7 +5,7 @@ description: "Install the sandbox World ID app and point your integration at the
 "twitter:image": "https://raw.githubusercontent.com/worldcoin/developer-docs/main/images/docs/docs-meta.png"
 ---
 
-{/* cspell:ignore idkit TestFlight VZEurhHe Eurh */}
+{/* cspell:ignore idkit TestFlight */}
 
 Getting set up in Sandbox has two parts: install the **sandbox World ID app** on your
 test device, and point your **integration** at the Sandbox environment. Both are
@@ -20,14 +20,34 @@ install them through the testing links below.
 
 ### iOS — TestFlight
 
+The sandbox build is distributed through a **private TestFlight group**, gated behind
+an enrollment request.
+
+#### Request tester access
+
 1. Install [TestFlight](https://apps.apple.com/app/testflight/id899247664) from the
    App Store if you don't have it.
-2. Open the public TestFlight link to join the external tester group:
-   [testflight.apple.com/join/VZEurhHe](https://testflight.apple.com/join/VZEurhHe)
-3. Install the **World ID (Sandbox)** build from TestFlight.
+2. In the [Developer Portal](https://developer.world.org), select **World ID Sandbox**
+   from the sidebar, choose the **iOS** tab, and submit the Apple Account email you
+   want enrolled. Enrollment is tied to a team, so open the sandbox panel from within
+   a team.
+3. Wait for approval. There is no public join link, each Apple Account email is
+   enrolled individually.
 
-No App Store Connect account or per-email invite is required — the public link admits
-you to the external tester group directly.
+#### Install the build
+
+1. Once your request is approved, you'll get an email confirmation.
+2. Open TestFlight on your iPhone. The **World ID (Sandbox)** build will now be
+   available there.
+3. Install it.
+
+#### Troubleshooting FAQ
+
+- Confirm the email you submitted is the Apple Account you'll use to sign in to
+  TestFlight, not any other email.
+- If your request was rejected or your access was revoked, submitting the same email
+  again won't create a new request. Contact Sandbox Support at
+  sandbox.access@toolsforhumanity.org.
 
 ### Android — Google Play
 

--- a/world-id/sandbox/sandbox-access.mdx
+++ b/world-id/sandbox/sandbox-access.mdx
@@ -20,8 +20,8 @@ install them through the testing links below.
 
 ### iOS — TestFlight
 
-The sandbox build is distributed through a **private TestFlight group**, gated behind
-an enrollment request.
+The sandbox build is distributed through TestFlight, and gated behind an enrollment
+request.
 
 #### Request tester access
 
@@ -31,14 +31,12 @@ an enrollment request.
    from the sidebar, choose the **iOS** tab, and submit the Apple Account email you
    want enrolled. Enrollment is tied to a team, so open the sandbox panel from within
    a team.
-3. Wait for approval. There is no public join link, each Apple Account email is
-   enrolled individually.
+3. Wait for approval.
 
 #### Install the build
 
-1. Once your request is approved, you'll get an email confirmation.
-2. Open TestFlight on your iPhone. The **World ID (Sandbox)** build will now be
-   available there.
+1. Once your request is approved, you'll get a TestFlight invitation email.
+2. Accept the invitation.
 3. Install it.
 
 #### Troubleshooting FAQ


### PR DESCRIPTION
## Summary

The sandbox access docs (https://docs.world.org/world-id/sandbox/sandbox-access) still described iOS access as joining a public TestFlight link, no App Store Connect account or per-email invite needed. That is no longer how it works.

The Developer Portal now has a submit-and-approve flow for iOS (worldcoin/developer-portal, `web/scenes/PortalV3/layout/Shell/SandboxButton.tsx`): you submit your Apple Account email, an admin approves it, approval enrolls that email in the App Store Connect beta group, and you then find the build in TestFlight. The old public join link env var isn't referenced anywhere in the developer portal app code anymore.

This traces back to MCORE-1773 (https://linear.app/worldcoin/issue/MCORE-1773), where the team decided to build a bespoke App Store Connect integration for iOS provisioning instead of Firebase. PR worldcoin/world-id-deploy#573 (https://github.com/worldcoin/world-id-deploy/pull/573) fixed the App Store Connect beta group ID that flow enrolls approved testers into.

This PR rewrites the iOS section to describe the real flow, structured the same way as the existing Android section (request tester access, install the build, troubleshooting).

Ticket: MCORE-1901 (https://linear.app/worldcoin/issue/MCORE-1901)

## Test plan
- [x] `pnpm exec cspell world-id/sandbox/sandbox-access.mdx` passes with no issues
- [ ] Preview the page and confirm the iOS section renders correctly