### PR TITLE
docs: add SolidRPC node provider

### DIFF
--- a/world-chain/providers/nodes.mdx
+++ b/world-chain/providers/nodes.mdx
@@ -37,6 +37,16 @@ QuickNode offers several benefits for developers building on World Chain, read m
 - [World Chain Sepolia](https://www.quicknode.com/chains/worldchain)
 - [Documentation](https://www.quicknode.com/chains/worldchain)
 
+## SolidRPC
+
+[SolidRPC](https://solidrpc.io) provides managed EVM JSON-RPC over HTTPS for World Chain, with upstream routing, failover, monitoring, and recovery handled behind a single integration. Authenticated plans support production workloads and historical access.
+
+See the [SolidRPC documentation](https://solidrpc.io/docs) to get started.
+
+### Supported networks
+
+- [World Chain](https://solidrpc.io/docs/networks)
+
 ## Tenderly RPC
 
 [Tenderly](https://tenderly.co/) is a blockchain development platform that provides tools for building, monitoring, and managing smart contracts on Ethereum and other EVM-compatible chains. They also provide node infrastructure services for World Chain.


### PR DESCRIPTION
## Summary

Adds SolidRPC to the World Chain node provider directory.

The entry lists authenticated HTTPS access for World Chain Mainnet, with upstream routing, failover, monitoring, and recovery handled behind a single integration.

The entry intentionally does not claim World Chain Sepolia, public keyless, or WebSocket support.

## Validation

- Confirmed World Chain appears in the SolidRPC network catalog
- Ran `pnpm exec cspell world-chain/providers/nodes.mdx --no-progress`
- Ran `pnpm check-links`
- Ran `git diff --check`