### PR TITLE
docs: update Selfie Check availability and V4 preset

### DIFF
--- a/world-id/SKILL.md
+++ b/world-id/SKILL.md
@@ -105,13 +105,6 @@ The credential decides what the user proves. Nail this down before scaffolding â
 
 Other legacy presets exist (`documentLegacy`, `deviceLegacy`); reach for them only when the user asks specifically. For sign-in / session reuse across visits, use the v4 **session** flow instead of a uniqueness preset (see the integrate doc).
 
-### Selfie Check (Beta) access
-
-Before implementing or testing Selfie Check, confirm that its feature flag is
-enabled for the target app. If it is not enabled, stop and tell the user to
-request access through their World contact or the documented support path. A
-valid app or action does not imply Selfie Check access.
-
 ## Phase 4 â€” Implement the 6 integration steps and explain the WHY
 
 The full code for each step is at [https://docs.world.org/world-id/idkit/integrate](https://docs.world.org/world-id/idkit/integrate). Don't reproduce it; link to it and adapt to the user's framework. The agent owns making sure each step is done **and understood**.

--- a/world-id/SKILL.md
+++ b/world-id/SKILL.md
@@ -99,9 +99,9 @@ The credential decides what the user proves. Nail this down before scaffolding �
 |---|---|---|
 | **`proofOfHuman`** — Proof of Human (flagship) | The user is a unique person, biometrically verified at an Orb | Sybil resistance, airdrops, one-vote-per-human, gated signups. **The default if the user said "proof of human" or "verify a real human."** |
 | **`passport`** — Passport | The user holds a valid government passport (NFC-verified) | Higher-assurance flows where you need document-grade identity (regulated apps, age-gating, KYC-adjacent). |
-| **`selfieCheckLegacy`** — Selfie Check (Beta) | A liveness selfie signal backed by a World ID 3.0 proof | Lower-assurance "is a human in front of the camera" — friction/bot deterrence without the full Orb requirement. |
+| **`selfieCheck`** — Selfie Check (Beta) | A liveness selfie signal backed by a World ID 4.0 proof | Lower-assurance "is a human in front of the camera" — friction/bot deterrence without the full Orb requirement. Use `selfieCheckLegacy` only when maintaining a World ID 3.0 integration. |
 
-**DO NOT default to `proofOfHuman` if the user said "passport" or "verify their ID"** — that's `passport`. **DO NOT default to `proofOfHuman` if the user said "selfie" or "liveness"** — that's `selfieCheckLegacy`. When in doubt, ask one question.
+**DO NOT default to `proofOfHuman` if the user said "passport" or "verify their ID"** — that's `passport`. **DO NOT default to `proofOfHuman` if the user said "selfie" or "liveness"** — that's `selfieCheck`. When in doubt, ask one question.
 
 Other legacy presets exist (`documentLegacy`, `deviceLegacy`); reach for them only when the user asks specifically. For sign-in / session reuse across visits, use the v4 **session** flow instead of a uniqueness preset (see the integrate doc).
 

--- a/world-id/credentials/11.mdx
+++ b/world-id/credentials/11.mdx
@@ -41,13 +41,8 @@ Use Selfie Check (Beta) for:
 Selfie Check has a 90-day inactivity window. After 90 days without use, the
 user completes the camera flow again before returning another proof.
 
-<Warning>
-  Selfie Check (Beta) is access-gated. To use it, [request access](mailto:developers@toolsforhumanity.com)
-  so the feature flag can be enabled for your app.
-</Warning>
-
-Once enabled, anyone with World ID App can use Selfie Check. No Orb, passport or
-other prerequisite credential is required.
+Anyone with World ID App can use Selfie Check. No Orb, passport or other
+prerequisite credential is required.
 
 ## How it works
 

--- a/world-id/idkit/credentials.mdx
+++ b/world-id/idkit/credentials.mdx
@@ -105,13 +105,8 @@ const preset = passport({ signal: "user-123" });
 
 ## Selfie Check (Beta)
 
-<Warning>
-  [Request access](mailto:developers@toolsforhumanity.com) to enable Selfie Check
-  (Beta) for your app.
-</Warning>
-
-Once enabled, use `selfieCheckLegacy()` to request Selfie Check. The preset
-currently uses World ID 3.0; World ID 4.0 support is not yet available.
+Use `selfieCheckLegacy()` to request Selfie Check. The preset currently uses
+World ID 3.0; World ID 4.0 support is not yet available.
 
 Anyone with World ID App can complete the flow—no Orb or document credential is
 required. Forward the complete IDKit result to the

--- a/world-id/idkit/credentials.mdx
+++ b/world-id/idkit/credentials.mdx
@@ -14,7 +14,7 @@ A [Credential](https://docs.rs/world-id-primitives/latest/world_id_primitives/cr
 | --- | --- | --- |
 | Proof of Human | The user is a unique human, backed by anonymous biometric verification by the Orb. | `proofOfHuman` |
 | Passport | The user holds a verified NFC passport credential. | `passport` |
-| Selfie Check (Beta) | A medium-assurance biometric credential using the device camera for liveness and facial similarity. | `selfieCheckLegacy` |
+| Selfie Check (Beta) | A medium-assurance biometric credential using the device camera for liveness and facial similarity. | `selfieCheck` |
 | Identity Check | An attestation that a document-backed property about the user matches your requested attributes. | `identityCheck` with attributes like `minimum_age`, `nationality`, or `document_type`. |
 
 You can also add a liveness check to any preset with `require_user_presence`.
@@ -25,7 +25,7 @@ You can also add a liveness check to any preset with `require_user_presence`.
 
 # SDK presets
 
-Preset helpers cover common credential requests: `proofOfHuman`, `passport`, `selfieCheckLegacy`, `identityCheck`, and the legacy presets.
+Preset helpers cover common credential requests: `proofOfHuman`, `passport`, `selfieCheck`, `identityCheck`, and the legacy presets.
 
 The snippets below assume `rp_context` was already generated and signed by your backend. See [Integrate IDKit](/world-id/idkit/integrate) for the full RP-signing flow.
 
@@ -105,8 +105,9 @@ const preset = passport({ signal: "user-123" });
 
 ## Selfie Check (Beta)
 
-Use `selfieCheckLegacy()` to request Selfie Check. The preset currently uses
-World ID 3.0; World ID 4.0 support is not yet available.
+Use `selfieCheck()` to request Selfie Check. This preset requests the World ID
+4.0 credential and disables fallback to legacy proofs. Use
+`selfieCheckLegacy()` only when maintaining a World ID 3.0 integration.
 
 Anyone with World ID App can complete the flow—no Orb or document credential is
 required. Forward the complete IDKit result to the
@@ -114,21 +115,22 @@ required. Forward the complete IDKit result to the
 
 <CodeGroup title="Selfie Check">
 ```typescript title="JavaScript"
-import { IDKit, selfieCheckLegacy } from "@worldcoin/idkit-core";
+import { IDKit, selfieCheck } from "@worldcoin/idkit-core";
 
-const preset = selfieCheckLegacy({ signal: "user-123" });
+const preset = selfieCheck({ signal: "user-123" });
 
 const request = await IDKit.request({
   app_id: "app_xxxxx",
   action: "my-action",
   rp_context,
+  allow_legacy_proofs: false,
 }).preset(preset);
 ```
 
 ```tsx title="React"
-import { IDKitRequestWidget, selfieCheckLegacy } from "@worldcoin/idkit";
+import { IDKitRequestWidget, selfieCheck } from "@worldcoin/idkit";
 
-const preset = selfieCheckLegacy({ signal: "user-123" });
+const preset = selfieCheck({ signal: "user-123" });
 
 <IDKitRequestWidget
   open={open}
@@ -136,6 +138,7 @@ const preset = selfieCheckLegacy({ signal: "user-123" });
   app_id="app_xxxxx"
   action="my-action"
   rp_context={rpContext}
+  allow_legacy_proofs={false}
   preset={preset}
   handleVerify={handleVerify}
   onSuccess={(result) => { /* ... */ }}

--- a/world-id/idkit/javascript.mdx
+++ b/world-id/idkit/javascript.mdx
@@ -28,7 +28,7 @@ yarn add @worldcoin/idkit-core
 
 - `IDKit.request(config)` for uniqueness proofs
 - `IDKit.requestWithInviteCode(config)` for invite-code mode
-- `orbLegacy`, `secureDocumentLegacy`, `documentLegacy`, `selfieCheckLegacy` for presets
+- `orbLegacy`, `secureDocumentLegacy`, `documentLegacy`, `selfieCheck` for presets
 
 Each entry point returns a builder. Finalize it with `.preset(...)`.
 
@@ -129,14 +129,14 @@ if (!completion.success) {
 Use `IDKit.requestWithInviteCode(config)` to open a landing page that displays both an invite code and a QR code. Validation, the returned `Status` shape, and the poll loop are identical to `IDKit.request`. See [Invite-code mode](/world-id/idkit/verification-flows#with-invite-code-mode) for when to use it.
 
 ```ts
-import { IDKit, selfieCheckLegacy } from "@worldcoin/idkit-core";
+import { IDKit, selfieCheck } from "@worldcoin/idkit-core";
 
 const request = await IDKit.requestWithInviteCode({
   app_id: "app_xxxxx",
   action: "my-action",
   rp_context,
-  allow_legacy_proofs: true,
-}).preset(selfieCheckLegacy({ signal: "user-123" }));
+  allow_legacy_proofs: false,
+}).preset(selfieCheck({ signal: "user-123" }));
 
 const connectorURI = request.connectorURI; // URL with &c=<code>&a=<app_id>
 const expiresAt = request.expiresAt;       // Unix seconds
@@ -173,8 +173,8 @@ const request = await IDKit.requestWithInviteCode({
   app_id: "app_xxxxx",
   action: "my-action",
   rp_context,
-  allow_legacy_proofs: true,
-}).preset(selfieCheckLegacy({ signal: "user-123" }));
+  allow_legacy_proofs: false,
+}).preset(selfieCheck({ signal: "user-123" }));
 
 const connectorURI = request.connectorURI;   // display to user (URL with code embedded)
 const expiresAt = request.expiresAt;         // drive a countdown

--- a/world-id/idkit/mini-apps.mdx
+++ b/world-id/idkit/mini-apps.mdx
@@ -37,7 +37,7 @@ The Mini-App-specific details:
 | Goal | IDKit preset |
 | --- | --- |
 | Strong sybil resistance or one-human-one-action checks | `proofOfHuman` |
-| Lower-friction liveness or bot deterrence | `selfieCheckLegacy` |
+| Lower-friction liveness or bot deterrence | `selfieCheck` |
 | Passport-backed checks | `passport` |
 
 Check out this [page](/world-id/idkit/credentials) to learn about the different World ID credentials and which preset to use for each.

--- a/world-id/idkit/react.mdx
+++ b/world-id/idkit/react.mdx
@@ -122,7 +122,7 @@ Hook result fields:
 For invite-code flows, use `IDKitInviteCodeRequestWidget` (controlled) or `useIDKitInviteCodeRequest` (headless). Config matches `IDKitRequestWidget` / `useIDKitRequest` — invite-code mode adds no new required fields. See [Invite-code mode](/world-id/idkit/verification-flows#with-invite-code-mode) for when to use it.
 
 ```tsx
-import { IDKitInviteCodeRequestWidget, selfieCheckLegacy } from "@worldcoin/idkit";
+import { IDKitInviteCodeRequestWidget, selfieCheck } from "@worldcoin/idkit";
 
 <IDKitInviteCodeRequestWidget
   open={open}
@@ -130,8 +130,8 @@ import { IDKitInviteCodeRequestWidget, selfieCheckLegacy } from "@worldcoin/idki
   app_id="app_xxxxx"
   action="my-action"
   rp_context={rpContext}
-  allow_legacy_proofs={true}
-  preset={selfieCheckLegacy({ signal: "user-123" })}
+  allow_legacy_proofs={false}
+  preset={selfieCheck({ signal: "user-123" })}
   handleVerify={async (result) => { /* ... */ }}
   onSuccess={() => { /* ... */ }}
 />;
@@ -172,7 +172,7 @@ import { IDKitRequestWidget, orbLegacy } from "@worldcoin/idkit";
 
 ```tsx
 // After — invite-code widget
-import { IDKitInviteCodeRequestWidget, selfieCheckLegacy } from "@worldcoin/idkit";
+import { IDKitInviteCodeRequestWidget, selfieCheck } from "@worldcoin/idkit";
 
 <IDKitInviteCodeRequestWidget
   open={open}
@@ -180,8 +180,8 @@ import { IDKitInviteCodeRequestWidget, selfieCheckLegacy } from "@worldcoin/idki
   app_id="app_xxxxx"
   action="my-action"
   rp_context={rpContext}
-  allow_legacy_proofs={true}
-  preset={selfieCheckLegacy({ signal: "user-123" })}
+  allow_legacy_proofs={false}
+  preset={selfieCheck({ signal: "user-123" })}
   handleVerify={handleVerify}
   onSuccess={onSuccess}
 />;

--- a/world-id/idkit/swift.mdx
+++ b/world-id/idkit/swift.mdx
@@ -82,7 +82,7 @@ Use `presetWithInviteCode(_:)` on the builder to return an `IDKitInviteCodeReque
 
 ```swift
 let request = try IDKit.request(config: config)
-  .presetWithInviteCode(selfieCheckLegacy(signal: "user-123"))
+  .presetWithInviteCode(selfieCheck(signal: "user-123"))
 
 let connectorURL = request.connectorURL  // URL with &c=<code>&a=<app_id>
 let expiresAt = request.expiresAt        // Date
@@ -103,7 +103,7 @@ let completion = await request.pollUntilCompletion()
 ```swift
 // After — invite-code mode
 let request = try IDKit.request(config: config)
-  .presetWithInviteCode(selfieCheckLegacy(signal: "user-123"))
+  .presetWithInviteCode(selfieCheck(signal: "user-123"))
 
 let connectorURL = request.connectorURL      // display to user (URL with code embedded)
 let expiresAt = request.expiresAt            // drive a countdown

--- a/world-id/idkit/verification-flows.mdx
+++ b/world-id/idkit/verification-flows.mdx
@@ -130,4 +130,4 @@ sequenceDiagram
 
 **Integrate**
 
-Setup is identical to the [standard integration](/world-id/idkit/integrate) — only the request call changes. Only the `selfieCheckLegacy` preset is supported for Selfie Check (Beta) today. It returns World ID 3.0 proofs; Selfie Check with World ID 4.0 is not available yet. For code samples and migration guides, see the per-SDK sections: [JavaScript](/world-id/idkit/javascript#invite-code-mode), [React](/world-id/idkit/react#invite-code-mode), [Swift](/world-id/idkit/swift#invite-code-mode).
+Setup is identical to the [standard integration](/world-id/idkit/integrate) — only the request call changes. Use the `selfieCheck` preset for World ID 4.0 Selfie Check proofs; it disables fallback to legacy proofs. Use `selfieCheckLegacy` only when maintaining a World ID 3.0 integration. For code samples and migration guides, see the per-SDK sections: [JavaScript](/world-id/idkit/javascript#invite-code-mode), [React](/world-id/idkit/react#invite-code-mode), [Swift](/world-id/idkit/swift#invite-code-mode).

--- a/world-id/sandbox/testing-selfie-check.mdx
+++ b/world-id/sandbox/testing-selfie-check.mdx
@@ -11,11 +11,6 @@ Sandbox lets you run the full [Selfie Check (Beta)](/world-id/credentials/11) re
 journey end-to-end — from your surface, through IDKit, into the sandbox World ID app,
 and back — without touching production identities or real proofs.
 
-<Warning>
-  Selfie Check (Beta) must be enabled for your app before you can test it. To
-  enable the feature flag, request access through your World point of contact.
-</Warning>
-
 New to Sandbox? Start with [What is Sandbox?](/world-id/sandbox/what-is-sandbox) and
 [How to get access](/world-id/sandbox/sandbox-access) before working through this
 guide.


### PR DESCRIPTION
## Summary
Updates the documentation regarding SelfieCheck in the developer docs
- remove Selfie Check access-gating warings from credential, IDKit, and Sandbox docs
- remove the corresponding internal World ID guidance so it cannot reintroduce the retired requirement of needing to sign up

## Reference
- https://github.com/worldcoin/developer-portal/pull/2313 — returns `enable_face_check: true` for every app from `/precheck` and removes the allowlist lookup
