### PR TITLE
docs(qa): Docs 3.0 QA round 2 — header tabs, footer, nav colors, alignment

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -159,6 +159,7 @@
     "testnet",
     "testnets",
     "thirdweb",
+    "topbar",
     "touchpoints",
     "tunnelmole",
     "tute",

--- a/docs.json
+++ b/docs.json
@@ -379,27 +379,46 @@
             ]
           }
         ]
+      },
+      {
+        "tab": "Resources",
+        "menu": [
+          {
+            "item": "World Tech Blog",
+            "href": "https://world.org/blog?blog_type=world-tech"
+          },
+          {
+            "item": "Open Source",
+            "href": "https://github.com/worldcoin"
+          },
+          {
+            "item": "Whitepaper",
+            "href": "https://whitepaper.world.org"
+          },
+          {
+            "item": "Ecosystem",
+            "href": "https://world.org/ecosystem"
+          }
+        ]
+      },
+      {
+        "tab": "Support",
+        "menu": [
+          {
+            "item": "Telegram Support Channel",
+            "href": "https://t.me/worlddevelopersupport"
+          },
+          {
+            "item": "Email Support",
+            "href": "mailto:developers@toolsforhumanity.com"
+          },
+          {
+            "item": "Mini Apps FAQ",
+            "href": "/mini-apps/more/faq"
+          }
+        ]
       }
-    ],
-    "global": {
-      "anchors": [
-        {
-          "anchor": "Telegram Support Channel",
-          "href": "https://t.me/worlddevelopersupport",
-          "icon": "telegram"
-        },
-        {
-          "anchor": "Email Support",
-          "href": "mailto:developers@toolsforhumanity.com",
-          "icon": "envelope"
-        },
-        {
-          "anchor": "GitHub",
-          "href": "https://github.com/worldcoin",
-          "icon": "github"
-        }
-      ]
-    }
+    ]
   },
   "logo": {
     "light": "/logo/world-developers.svg",
@@ -423,7 +442,37 @@
       "x": "https://x.com/worldnetwork",
       "github": "https://github.com/worldcoin",
       "discord": "https://world.org/discord"
-    }
+    },
+    "links": [
+      {
+        "items": [
+          {
+            "label": "About World",
+            "href": "https://world.org"
+          },
+          {
+            "label": "Developers",
+            "href": "https://world.org/developers"
+          },
+          {
+            "label": "Whitepaper",
+            "href": "https://whitepaper.world.org"
+          },
+          {
+            "label": "Open Source",
+            "href": "https://github.com/worldcoin"
+          },
+          {
+            "label": "Ecosystem",
+            "href": "https://world.org/ecosystem"
+          },
+          {
+            "label": "Careers",
+            "href": "https://world.org/careers"
+          }
+        ]
+      }
+    ]
   },
   "contextual": {
     "options": [

--- a/index.mdx
+++ b/index.mdx
@@ -26,7 +26,7 @@ import { DeveloperStories } from "/snippets/developer-stories.jsx";
 <Visibility for="humans">
 <div className="landing-container">
 
-<div style={{ marginBottom: "128px" }}>
+<div style={{ marginBottom: "160px" }}>
   <h1 className="landing-hero-title" style={{ margin: 0 }}>World Developer Docs</h1>
   <div className="landing-hero-sub">
     Integrate World ID and deploy on World Chain with official developer documentation.
@@ -37,7 +37,7 @@ import { DeveloperStories } from "/snippets/developer-stories.jsx";
 
   <a href="/world-id/overview" className="product-card">
     <div className="product-card-tile">
-      <img src="/icons/landing/world-id.svg" alt="" className="product-card-icon" style={{ width: "40px", height: "40px", display: "block" }} />
+      <img src="/icons/landing/world-id.svg" alt="" className="product-card-icon" style={{ width: "32px", height: "32px", display: "block" }} />
     </div>
     <div>
       <div className="product-card-title" style={{ fontSize: "32px", lineHeight: 1.2, letterSpacing: "-0.32px", fontWeight: 300 }}>Integrate World ID</div>
@@ -47,7 +47,7 @@ import { DeveloperStories } from "/snippets/developer-stories.jsx";
 
   <a href="/mini-apps" className="product-card">
     <div className="product-card-tile">
-      <img src="/icons/landing/mini-app.svg" alt="" className="product-card-icon" style={{ width: "40px", height: "40px", display: "block" }} />
+      <img src="/icons/landing/mini-app.svg" alt="" className="product-card-icon" style={{ width: "32px", height: "32px", display: "block" }} />
     </div>
     <div>
       <div className="product-card-title" style={{ fontSize: "32px", lineHeight: 1.2, letterSpacing: "-0.32px", fontWeight: 300 }}>Create a Mini App</div>
@@ -57,7 +57,7 @@ import { DeveloperStories } from "/snippets/developer-stories.jsx";
 
   <a href="/agents/agent-kit/integrate" className="product-card">
     <div className="product-card-tile">
-      <img src="/icons/landing/agentkit.svg" alt="" className="product-card-icon" style={{ width: "40px", height: "40px", display: "block" }} />
+      <img src="/icons/landing/agentkit.svg" alt="" className="product-card-icon" style={{ width: "32px", height: "32px", display: "block" }} />
     </div>
     <div>
       <div className="product-card-title" style={{ fontSize: "32px", lineHeight: 1.2, letterSpacing: "-0.32px", fontWeight: 300 }}>AgentKit</div>
@@ -67,7 +67,7 @@ import { DeveloperStories } from "/snippets/developer-stories.jsx";
 
   <a href="/world-chain" className="product-card">
     <div className="product-card-tile">
-      <img src="/icons/landing/world-chain.svg" alt="" className="product-card-icon" style={{ width: "40px", height: "40px", display: "block" }} />
+      <img src="/icons/landing/world-chain.svg" alt="" className="product-card-icon" style={{ width: "32px", height: "32px", display: "block" }} />
     </div>
     <div>
       <div className="product-card-title" style={{ fontSize: "32px", lineHeight: 1.2, letterSpacing: "-0.32px", fontWeight: 300 }}>World Chain</div>
@@ -77,7 +77,7 @@ import { DeveloperStories } from "/snippets/developer-stories.jsx";
 
 </div>
 
-<div style={{ marginBottom: "192px" }}>
+<div style={{ marginBottom: "240px" }}>
   <DeveloperStories
     title="Developer stories"
     subtitle="See how developers build trusted, human-centered apps with World."
@@ -107,8 +107,8 @@ import { DeveloperStories } from "/snippets/developer-stories.jsx";
   />
 </div>
 
-<div style={{ marginBottom: "128px" }}>
-  <div className="landing-section-title" style={{ marginBottom: "48px" }}>World Tech Updates</div>
+<div style={{ marginBottom: "240px" }}>
+  <div className="landing-section-title" style={{ marginBottom: "40px" }}>World Tech Updates</div>
   <div className="landing-updates">
     <a className="landing-update" href="https://world.org/blog/engineering/world-chain-full-block-access-lists" target="_blank" rel="noopener noreferrer">
       <div className="landing-update-title">World Chain launches full block access lists</div>
@@ -123,7 +123,7 @@ import { DeveloperStories } from "/snippets/developer-stories.jsx";
       <p className="landing-update-desc">The new World ID 4.0 upgrade introduces account abstraction with multi-key support, transforming a World ID from a single secret into an abstract record in a public registry. This increases protocol resilience by allowing the introduction of multiple key support, portability, recovery and improved privacy.</p>
     </a>
   </div>
-  <a href="https://world.org/blog/engineering" target="_blank" rel="noopener noreferrer" className="landing-link" style={{ display: "inline-block", fontSize: "16px", marginTop: "32px", textDecoration: "none" }}>
+  <a href="https://world.org/blog?blog_type=world-tech" target="_blank" rel="noopener noreferrer" className="landing-link" style={{ display: "inline-block", fontSize: "16px", marginTop: "48px", textDecoration: "underline", textUnderlineOffset: "4px" }}>
     Go to World Tech
   </a>
 </div>
@@ -200,5 +200,5 @@ import { DeveloperStories } from "/snippets/developer-stories.jsx";
   - [World Chain launches full block access lists](https://world.org/blog/engineering/world-chain-full-block-access-lists) — World Chain now streams full EIP-7928 block access lists in every flashblock, enabling parallel block verification, faster validation, and a path toward gigagas-per-second throughput without increasing validator hardware requirements.
   - [Remainder: World's GKR prover for ML and more](https://world.org/blog/engineering/world-zkgpu-for-ml-and-more) — Remainder (Reasonable Machine Learning Doubly-Efficient Prover) is Tools for Humanity's open-sourced in-house GKR + Hyrax proof system. It enables World's users to run ML models locally over private data and prove that they executed them correctly.
   - [Introducing World ID 4.0 - Request for Comments](https://world.org/blog/engineering/introducing-world-id-4.0) — World ID 4.0 introduces account abstraction with multi-key support, transforming a World ID from a single secret into an abstract record in a public registry, improving resilience, portability, recovery and privacy.
-  - More at [World Tech](https://world.org/blog/engineering).
+  - More at [World Tech](https://world.org/blog?blog_type=world-tech).
 </Visibility>

--- a/tailwind.css
+++ b/tailwind.css
@@ -21,11 +21,18 @@
 }
 
 @layer components {
-  /* Tint the custom Proof of Human badge when its sidebar page is selected. */
-  #sidebar-content
-    li[data-active]
-    img[src$="/images/docs/human-badge-gray.svg"] {
-    content: url("/images/docs/human-badge-blue.svg");
+  /* Sidebar — selected item is a neutral pill per Docs 3.0 (bg gray/a9, ink text),
+     replacing the theme-default blue tint. The Proof of Human badge keeps its
+     gray artwork in both states for the same reason. */
+  #sidebar-content li[data-active="true"] > a {
+    background-color: #F3F2F0 !important;
+    color: #181818 !important;
+    border-radius: 6px !important;
+    text-shadow: none !important;
+  }
+  .dark #sidebar-content li[data-active="true"] > a {
+    background-color: rgba(255, 255, 255, 0.08) !important;
+    color: #F3F2F0 !important;
   }
 
   /* Page content text links only (anchors without custom classes) */
@@ -150,14 +157,22 @@
   }
 
   /* Landing page — developer stories carousel.
-     Cards are 4:3 (756x567 in the mock); two fill the content column with the
-     third peeking past the edge, matching the design's resting composition.
-     Kept as a CSS class on purpose: an arbitrary utility like
-     w-[min(760px,85%)] is silently dropped by Mintlify's Tailwind compiler
-     (values with a comma + %), which renders the cards at zero size. */
+     Cards are 4:3 (756x567 in the mock); two fill the content column exactly
+     (24px gap) and the track bleeds into the right page gutter so the third
+     card peeks past the content edge, matching the design's resting
+     composition. Card width is derived from the bled track width (content
+     width + 96px gutter). Kept as a CSS class on purpose: an arbitrary
+     utility like w-[min(760px,85%)] is silently dropped by Mintlify's
+     Tailwind compiler (values with a comma + %), which renders the cards at
+     zero size. */
   .landing-story-card {
-    width: calc(50% - 44px);
+    width: calc((100% - 96px) / 2 - 12px);
     aspect-ratio: 4 / 3;
+  }
+  @media (min-width: 901px) {
+    .landing-stories-track {
+      margin-right: -96px;
+    }
   }
   @media (max-width: 900px) {
     .landing-story-card {
@@ -188,11 +203,19 @@
     background-color: rgb(32, 33, 36);
   }
 
-  /* Landing page — World Tech updates list (no divider rules, per design) */
+  /* Landing page — World Tech updates list; rows separated by hairline rules
+     (above each row and below the last) per the Docs 3.0 QA design. */
   .landing-update {
     display: block;
-    padding: 32px 0;
+    padding: 40px 0;
+    border-top: 1px solid #E1DFDA;
     text-decoration: none;
+  }
+  .landing-update:last-child {
+    border-bottom: 1px solid #E1DFDA;
+  }
+  .dark .landing-update {
+    border-color: rgba(255, 255, 255, 0.12);
   }
   .landing-update-title {
     font-size: 24px;
@@ -210,7 +233,7 @@
   }
   .landing-update-desc {
     margin: 12px 0 0;
-    max-width: 1100px;
+    max-width: 886px;
     font-size: 16px;
     line-height: 1.5;
     font-weight: 300;
@@ -354,8 +377,8 @@
     color: #F3F2F0;
   }
   .landing-hero-sub {
-    margin-top: 20px;
-    max-width: 640px;
+    margin-top: 24px;
+    max-width: 487px;
     font-size: 24px;
     line-height: 1.35;
     letter-spacing: -0.24px;
@@ -380,7 +403,7 @@
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     column-gap: 80px;
-    row-gap: 104px;
+    row-gap: 113px;
   }
   @media (max-width: 900px) {
     .landing-card-grid {
@@ -411,6 +434,183 @@
     .landing-container {
       padding: 32px 16px 0;
     }
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Header (Docs 3.0 QA) — align the navbar container with the page     */
+  /* content (1728px max, 96px gutters at desktop) and restyle tabs to   */
+  /* the design language: ink pill for the active tab, ink labels, no    */
+  /* underline indicator.                                                */
+  /* ------------------------------------------------------------------ */
+  @media (min-width: 1024px) {
+    /* Both the navbar container and the docs-page body use Mintlify's
+       max-w-8xl (the body via a peer-variant class), so match them to the
+       1728px design frame. */
+    [class*="max-w-8xl"] {
+      max-width: 1728px !important;
+    }
+    /* Navbar top row (logo/search/CTA) and tab row: 48px → 96px gutters,
+       aligning the logo and tabs with the hero and content below. */
+    #navbar .lg\:px-12,
+    #navbar .px-12 {
+      padding-left: 96px !important;
+      padding-right: 96px !important;
+    }
+    /* Docs pages: pull the sidebar/content wrapper out to the same frame
+       so the sidebar lines up under the logo (group headers and link text
+       both carry a 16px inset, so 80px padding lands them at 96px).
+       Scoped to non-custom pages; the homepage manages its own gutters. */
+    body:has(#navbar.is-not-custom) div[class*="is-not-custom]:px-4"] {
+      padding-left: 80px !important;
+      padding-right: 80px !important;
+    }
+  }
+
+  /* Tab bar — pill tabs per Docs 3.0 header design */
+  #navbar .nav-tabs {
+    align-items: center;
+    gap: 4px;
+  }
+  #navbar .nav-tabs-item {
+    height: 32px !important;
+    padding: 6px 14px;
+    border-radius: 42px;
+    color: #181818 !important;
+    transition: background-color 0.15s ease;
+  }
+  #navbar .nav-tabs-item:hover {
+    color: #181818 !important;
+    background-color: #F3F2F0;
+  }
+  #navbar .nav-tabs-item[data-active="true"] {
+    background-color: #181818;
+    color: #F9F9F8 !important;
+    text-shadow: none;
+  }
+  #navbar .nav-tabs-item[data-active="true"]:hover {
+    color: #F9F9F8 !important;
+    background-color: #181818;
+  }
+  /* The theme's active-tab underline indicator */
+  #navbar .nav-tabs-item > div.absolute {
+    display: none;
+  }
+  /* Hairline divider between the page tabs and the Resources/Support
+     menus (the menu tabs render as <button>, page tabs as <a>). */
+  #navbar .nav-tabs > button.nav-tabs-item:first-of-type {
+    margin-left: 21px;
+  }
+  #navbar .nav-tabs > button.nav-tabs-item:first-of-type::before {
+    content: "";
+    position: absolute;
+    left: -13px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 1px;
+    height: 24px;
+    background-color: #E1DFDA;
+  }
+  .dark #navbar .nav-tabs > button.nav-tabs-item:first-of-type::before {
+    background-color: rgba(255, 255, 255, 0.15);
+  }
+  .dark #navbar .nav-tabs-item {
+    color: #F3F2F0 !important;
+  }
+  .dark #navbar .nav-tabs-item:hover {
+    color: #F3F2F0 !important;
+    background-color: rgba(255, 255, 255, 0.08);
+  }
+  .dark #navbar .nav-tabs-item[data-active="true"],
+  .dark #navbar .nav-tabs-item[data-active="true"]:hover {
+    background-color: #F3F2F0;
+    color: #181818 !important;
+  }
+
+  /* Search entry — quiet bordered pill per design */
+  #navbar #search-bar-entry {
+    border-radius: 20px;
+    background-color: #F9F9F8;
+    box-shadow: none;
+    --tw-ring-color: #E1DFDA;
+    color: #181818;
+  }
+  .dark #navbar #search-bar-entry {
+    background-color: rgb(24, 25, 27);
+    --tw-ring-color: rgba(255, 255, 255, 0.15);
+    color: #F3F2F0;
+  }
+
+  /* Developer Portal CTA — pill radius to match the design language */
+  #topbar-cta-button a > span.absolute {
+    border-radius: 20px;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Docs-page footer (Docs 3.0) — restyle Mintlify's advanced footer    */
+  /* into the design's single row: "™ 2026 World" left, links right.     */
+  /* The homepage keeps its own hand-built .landing-footer.              */
+  /* ------------------------------------------------------------------ */
+  #footer.advanced-footer {
+    border-top: none;
+  }
+  #footer.advanced-footer > div {
+    max-width: 1728px !important;
+  }
+  @media (min-width: 1024px) {
+    #footer.advanced-footer > div {
+      padding: 48px 96px 64px !important;
+    }
+  }
+  /* Replace the footer logo with the trademark line from the design. */
+  #footer.advanced-footer .nav-logo {
+    display: none !important;
+  }
+  #footer.advanced-footer a.select-none::after {
+    content: "™ 2026 World";
+    font-size: 16px;
+    line-height: 1.4;
+    font-weight: 300;
+    color: #181818;
+    white-space: nowrap;
+  }
+  .dark #footer.advanced-footer a.select-none::after {
+    color: #F3F2F0;
+  }
+  /* Link row: right-aligned single row, ink links per design. */
+  @media (min-width: 768px) {
+    #footer.advanced-footer .md\:justify-center {
+      justify-content: flex-end !important;
+      gap: 40px !important;
+    }
+  }
+  #footer.advanced-footer a[class*="max-w-36"] {
+    max-width: none !important;
+    font-size: 16px !important;
+    line-height: 1.4;
+    font-weight: 300;
+    color: #181818 !important;
+  }
+  #footer.advanced-footer a[class*="max-w-36"]:hover {
+    color: #181818 !important;
+    text-decoration: underline;
+    text-underline-offset: 4px;
+  }
+  .dark #footer.advanced-footer a[class*="max-w-36"],
+  .dark #footer.advanced-footer a[class*="max-w-36"]:hover {
+    color: #F3F2F0 !important;
+  }
+  /* The design's footer carries no social icons (those links live in the
+     Resources/Support menus and the links row). */
+  #footer.advanced-footer div[class*="min-w-[140px]"] {
+    display: none !important;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Assistant chat — hide the floating draggable chat launcher; the     */
+  /* assistant stays reachable from the header (Ask Assistant / search). */
+  /* ------------------------------------------------------------------ */
+  body > div.z-999.cursor-grab.touch-none[role="status"] {
+    display: none !important;
   }
 
 }


### PR DESCRIPTION
Second design-QA pass against the [World Website Handoff Figma](https://www.figma.com/design/8xRcNNztnzJ1TnGBTsSdk9/World-Website-Handoff?node-id=78456-89219) (\"Homepage - live\" annotated frame + the updated \`Developer Docs / Desktop 1728px\` design frames).

## The six requested fixes

1. **Align main content and hero width (homepage)** — the Mintlify header container was \`max-w-8xl\` with 48px gutters (logo at ~169px) while the hero/content sit at 96px. The navbar (both rows) now uses the 1728px design frame with 96px gutters, so logo, tabs, hero, and content share the same left edge. Docs pages pull the sidebar wrapper to the same frame (sidebar text lands at 96px under the logo).
2. **New header design** — took the sanctioned fallback plus polish: added **Resources** and **Support** as dropdown tabs (native \`menu\` tabs), with the design's hairline divider separating them from the page tabs, and restyled the tab bar to the design language — ink labels, black pill on the active tab (inverted in dark mode), no underline, search entry as the quiet bordered pill. The full floating single-row pill header would require fragile CSS surgery on Mintlify's two-row DOM, so it was skipped per the \"if that's too complicated\" note.
   - Resources: World Tech Blog / Open Source / Whitepaper / Ecosystem
   - Support: Telegram Support Channel / Email Support / Mini Apps FAQ
   - The old global sidebar anchors (Telegram/Email/GitHub) moved into these menus — the design's sidebar shows no anchors. Shout if you want them back.
3. **Missing footer** — docs pages now render a footer via \`footer.links\`, restyled to the design's single row: \`™ 2026 World\` left, six ink links right, aligned to the 96px gutters. Social icons are hidden per the design (one-line revert if unwanted). \"Powered by Mintlify\" was left untouched. The homepage keeps its hand-built footer.
4. **Chat window removed** — the floating draggable assistant launcher (bottom-left) is hidden via CSS (there is no docs.json toggle for it); the assistant stays reachable from the header.
5. **World Tech link** — now \`https://world.org/blog?blog_type=world-tech\` in both visibility twins, underlined per the design.
6. **Sidebar selected color** — neutral pill per the design (\`#F3F2F0\` bg, \`#181818\` text, 6px radius) instead of theme blue, with a dark-mode equivalent; the blue Proof-of-Human badge swap is dropped to stay monochrome.

## Detail pass from the design frames

Since the Figma comments were unreachable this session (see note below), I diffed the design frames against the live implementation directly:

- World Tech Updates rows: hairline dividers above each row and below the last (\`#E1DFDA\`), 40px row padding, description max-width 886px, \"Go to World Tech\" underlined with 48px top margin
- Hero: sub max-width 487px (wraps like the mock), 24px gap under the title
- Developer stories: cards 756px at 1536 content width with a 24px gap; the track now bleeds into the right gutter so the third card peeks past the content edge exactly as in the mock (cards land at x = 96 / 876 / 1656 at 1728px)
- Product cards: icons 40px → 32px, row gap 113px
- Section rhythm: hero → cards 160px, then 240px between sections

## Not done / for review

- **Figma comment details** — Soam's seat can't read comments via API, and the Claude-in-Chrome session workflow wasn't available this run. If any comment-level nits aren't covered by the above, they'll need one more pass.
- **Newsletter** — still commented out pending a public subscribe endpoint (worldcoin/company-website#4481).
- **Resources/Support menu contents** — the design shows the dropdowns closed, so the entries are my best mapping; happy to swap in the intended lists.

Verified locally with \`mint dev\` at 1728px/desktop/mobile, light + dark, plus \`mint broken-links\` and \`cspell\` (both clean).