### PR TITLE
docs(footer): add the Docs 3.0 footer to docs pages

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -423,7 +423,37 @@
       "x": "https://x.com/worldnetwork",
       "github": "https://github.com/worldcoin",
       "discord": "https://world.org/discord"
-    }
+    },
+    "links": [
+      {
+        "items": [
+          {
+            "label": "About World",
+            "href": "https://world.org"
+          },
+          {
+            "label": "Developers",
+            "href": "https://world.org/developers"
+          },
+          {
+            "label": "Whitepaper",
+            "href": "https://whitepaper.world.org"
+          },
+          {
+            "label": "Open Source",
+            "href": "https://github.com/worldcoin"
+          },
+          {
+            "label": "Ecosystem",
+            "href": "https://world.org/ecosystem"
+          },
+          {
+            "label": "Careers",
+            "href": "https://world.org/careers"
+          }
+        ]
+      }
+    ]
   },
   "contextual": {
     "options": [

--- a/tailwind.css
+++ b/tailwind.css
@@ -308,6 +308,66 @@
   .dark .landing-footer-links {
     color: #F3F2F0;
   }
+
+  /* ------------------------------------------------------------------ */
+  /* Docs-page footer (Docs 3.0) — restyle Mintlify's advanced footer    */
+  /* into the design's single row: "™ 2026 World" left, links right.     */
+  /* The homepage keeps its own hand-built .landing-footer.              */
+  /* ------------------------------------------------------------------ */
+  #footer.advanced-footer {
+    border-top: none;
+  }
+  #footer.advanced-footer > div {
+    max-width: 1728px !important;
+  }
+  @media (min-width: 1024px) {
+    #footer.advanced-footer > div {
+      padding: 48px 96px 64px !important;
+    }
+  }
+  /* Replace the footer logo with the trademark line from the design. */
+  #footer.advanced-footer .nav-logo {
+    display: none !important;
+  }
+  #footer.advanced-footer a.select-none::after {
+    content: "™ 2026 World";
+    font-size: 16px;
+    line-height: 1.4;
+    font-weight: 300;
+    color: #181818;
+    white-space: nowrap;
+  }
+  .dark #footer.advanced-footer a.select-none::after {
+    color: #F3F2F0;
+  }
+  /* Link row: right-aligned single row, ink links per design. */
+  @media (min-width: 768px) {
+    #footer.advanced-footer .md\:justify-center {
+      justify-content: flex-end !important;
+      gap: 40px !important;
+    }
+  }
+  #footer.advanced-footer a[class*="max-w-36"] {
+    max-width: none !important;
+    font-size: 16px !important;
+    line-height: 1.4;
+    font-weight: 300;
+    color: #181818 !important;
+  }
+  #footer.advanced-footer a[class*="max-w-36"]:hover {
+    color: #181818 !important;
+    text-decoration: underline;
+    text-underline-offset: 4px;
+  }
+  .dark #footer.advanced-footer a[class*="max-w-36"],
+  .dark #footer.advanced-footer a[class*="max-w-36"]:hover {
+    color: #F3F2F0 !important;
+  }
+  /* The design's footer carries no social icons (those links live in the
+     footer links row; GitHub also sits in the Resources menu). */
+  #footer.advanced-footer div[class*="min-w-[140px]"] {
+    display: none !important;
+  }
   @media (max-width: 900px) {
     .landing-footer-inner {
       padding: 0 24px 48px;


### PR DESCRIPTION
## Change

"Add the missing footer" — docs pages only rendered social icons and the Mintlify attribution at the end of the content column. This adds `footer.links` (About World · Developers · Whitepaper · Open Source · Ecosystem · Careers) and restyles Mintlify's advanced footer into the design's single row: **™ 2026 World** left, six ink links right, full-width and aligned to the 96px page gutters.

- Social icons are hidden per the design (their links live in the footer row / Resources menu) — a one-rule revert if unwanted.
- "Powered by Mintlify" is left untouched.
- The homepage keeps its own hand-built footer (custom mode), unaffected here.

## Docs-page footer

**Before:**

![before](https://raw.githubusercontent.com/worldcoin/developer-docs/f2a651a14dccd600d02ce747f6d40f9b368ff2da/qa/docs3-round2/pr3-before.png)

**After:**

![after](https://raw.githubusercontent.com/worldcoin/developer-docs/f2a651a14dccd600d02ce747f6d40f9b368ff2da/qa/docs3-round2/pr3-after.png)
