### PR TITLE
docs(ui): hide the floating assistant chat launcher

### DIFF
--- a/tailwind.css
+++ b/tailwind.css
@@ -78,6 +78,20 @@
     display: none !important;
   }
 
+  /* ------------------------------------------------------------------ */
+  /* Assistant chat — remove the duplicate chat entry points; the        */
+  /* assistant stays reachable from the header (Ask Assistant / ⌘I).     */
+  /* The hosted site renders a sticky "Ask a question" bar at the bottom */
+  /* of every docs page; local `mint dev` renders a draggable floating   */
+  /* launcher instead. Hide both.                                        */
+  /* ------------------------------------------------------------------ */
+  div[data-assistant-bar] {
+    display: none !important;
+  }
+  body > div.z-999.cursor-grab.touch-none[role="status"] {
+    display: none !important;
+  }
+
   /* Landing page — product cards (borderless icon-tile rows per Docs 3.0) */
   a.product-card {
     display: flex;


### PR DESCRIPTION
Part of the Docs 3.0 QA round 2 series (splitting #170 into reviewable pieces — this PR is independent and can merge in any order).

## Change

"Remove the chat window, since we already have it in the header." The chat window on the **hosted site** is the sticky **"Ask a question…" bar** docked at the bottom of every docs page (`div[data-assistant-bar]`) — it overlays the content while reading. Local `mint dev` renders the same assistant as a draggable floating launcher (bottom-left bubble) instead. This PR hides **both** with two scoped CSS rules — neither has a docs.json toggle.

The assistant itself is untouched: the header's **Ask Assistant (⌘I)** entry still opens the docked assistant panel (verified on production with this exact rule injected).

## Docs page on production — bottom of the viewport while reading

**Before** (the bar floats over the content):

![before](https://raw.githubusercontent.com/worldcoin/developer-docs/914a29ce1bf4be2f67eaf50bbabb0eda43699dd2/qa/docs3-round2/pr4-prod-before.png)

**After** (same page with this PR's CSS applied):

![after](https://raw.githubusercontent.com/worldcoin/developer-docs/914a29ce1bf4be2f67eaf50bbabb0eda43699dd2/qa/docs3-round2/pr4-prod-after.png)

## Local dev — the same feature's floating launcher, also hidden

**Before:**

![before](https://raw.githubusercontent.com/worldcoin/developer-docs/914a29ce1bf4be2f67eaf50bbabb0eda43699dd2/qa/docs3-round2/pr4-before.png)

**After:**

![after](https://raw.githubusercontent.com/worldcoin/developer-docs/914a29ce1bf4be2f67eaf50bbabb0eda43699dd2/qa/docs3-round2/pr4-after.png)
