### PR TITLE
docs(home): point World Tech links at the world-tech blog filter

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -123,7 +123,7 @@ import { DeveloperStories } from "/snippets/developer-stories.jsx";
       <p className="landing-update-desc">The new World ID 4.0 upgrade introduces account abstraction with multi-key support, transforming a World ID from a single secret into an abstract record in a public registry. This increases protocol resilience by allowing the introduction of multiple key support, portability, recovery and improved privacy.</p>
     </a>
   </div>
-  <a href="https://world.org/blog/engineering" target="_blank" rel="noopener noreferrer" className="landing-link" style={{ display: "inline-block", fontSize: "16px", marginTop: "32px", textDecoration: "none" }}>
+  <a href="https://world.org/blog?blog_type=world-tech" target="_blank" rel="noopener noreferrer" className="landing-link" style={{ display: "inline-block", fontSize: "16px", marginTop: "48px", textDecoration: "underline", textUnderlineOffset: "4px" }}>
     Go to World Tech
   </a>
 </div>
@@ -200,5 +200,5 @@ import { DeveloperStories } from "/snippets/developer-stories.jsx";
   - [World Chain launches full block access lists](https://world.org/blog/engineering/world-chain-full-block-access-lists) — World Chain now streams full EIP-7928 block access lists in every flashblock, enabling parallel block verification, faster validation, and a path toward gigagas-per-second throughput without increasing validator hardware requirements.
   - [Remainder: World's GKR prover for ML and more](https://world.org/blog/engineering/world-zkgpu-for-ml-and-more) — Remainder (Reasonable Machine Learning Doubly-Efficient Prover) is Tools for Humanity's open-sourced in-house GKR + Hyrax proof system. It enables World's users to run ML models locally over private data and prove that they executed them correctly.
   - [Introducing World ID 4.0 - Request for Comments](https://world.org/blog/engineering/introducing-world-id-4.0) — World ID 4.0 introduces account abstraction with multi-key support, transforming a World ID from a single secret into an abstract record in a public registry, improving resilience, portability, recovery and privacy.
-  - More at [World Tech](https://world.org/blog/engineering).
+  - More at [World Tech](https://world.org/blog?blog_type=world-tech).
 </Visibility>

--- a/tailwind.css
+++ b/tailwind.css
@@ -188,11 +188,19 @@
     background-color: rgb(32, 33, 36);
   }
 
-  /* Landing page — World Tech updates list (no divider rules, per design) */
+  /* Landing page — World Tech updates list; rows separated by hairline rules
+     (above each row and below the last) per the Docs 3.0 QA design. */
   .landing-update {
     display: block;
-    padding: 32px 0;
+    padding: 40px 0;
+    border-top: 1px solid #E1DFDA;
     text-decoration: none;
+  }
+  .landing-update:last-child {
+    border-bottom: 1px solid #E1DFDA;
+  }
+  .dark .landing-update {
+    border-color: rgba(255, 255, 255, 0.12);
   }
   .landing-update-title {
     font-size: 24px;
@@ -210,7 +218,7 @@
   }
   .landing-update-desc {
     margin: 12px 0 0;
-    max-width: 1100px;
+    max-width: 886px;
     font-size: 16px;
     line-height: 1.5;
     font-weight: 300;


### PR DESCRIPTION
## Change

- "Go to World Tech" now points at **https://world.org/blog?blog_type=world-tech** (updated in both the visible landing block and the copy-page export twin), underlined with a 48px top margin per the design.
- The World Tech Updates rows pick up the design's hairline dividers (`#E1DFDA`, above each row and below the last), 40px row padding, and the 886px description measure.

## World Tech Updates section

**Before:**

![before](https://raw.githubusercontent.com/worldcoin/developer-docs/f2a651a14dccd600d02ce747f6d40f9b368ff2da/qa/docs3-round2/pr5-before.png)

**After:**

![after](https://raw.githubusercontent.com/worldcoin/developer-docs/f2a651a14dccd600d02ce747f6d40f9b368ff2da/qa/docs3-round2/pr5-after.png)
