### PR TITLE
docs(nav): neutral selected state for sidebar items

### DIFF
--- a/tailwind.css
+++ b/tailwind.css
@@ -21,11 +21,18 @@
 }
 
 @layer components {
-  /* Tint the custom Proof of Human badge when its sidebar page is selected. */
-  #sidebar-content
-    li[data-active]
-    img[src$="/images/docs/human-badge-gray.svg"] {
-    content: url("/images/docs/human-badge-blue.svg");
+  /* Sidebar — selected item is a neutral pill per Docs 3.0 (bg gray/a9, ink
+     text), replacing the theme-default blue tint. The Proof of Human badge
+     keeps its gray artwork in both states for the same reason. */
+  #sidebar-content li[data-active="true"] > a {
+    background-color: #F3F2F0 !important;
+    color: #181818 !important;
+    border-radius: 6px !important;
+    text-shadow: none !important;
+  }
+  .dark #sidebar-content li[data-active="true"] > a {
+    background-color: rgba(255, 255, 255, 0.08) !important;
+    color: #F3F2F0 !important;
   }
 
   /* Page content text links only (anchors without custom classes) */


### PR DESCRIPTION
## Change

"Change the color of the selected item in the side navigation to match the design" — the selected sidebar item now uses the design's neutral pill (`#F3F2F0` background, `#181818` text, 6px radius, no faux-bold text-shadow) instead of the theme's blue tint, with a dark-mode equivalent (white/8% on `#F3F2F0` text). The blue Proof-of-Human badge swap is dropped so the badge stays gray in both states, matching the monochrome sidebar.

## Sidebar

**Before:**

![before](https://raw.githubusercontent.com/worldcoin/developer-docs/f2a651a14dccd600d02ce747f6d40f9b368ff2da/qa/docs3-round2/pr6-before.png)

**After:**

![after](https://raw.githubusercontent.com/worldcoin/developer-docs/f2a651a14dccd600d02ce747f6d40f9b368ff2da/qa/docs3-round2/pr6-after.png)
