### PR TITLE
docs(nav): header responds to its own width; identical chrome at every size

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -428,19 +428,6 @@
     "light": "/logo/world-developers.svg",
     "dark": "/logo/world-developers-white.svg"
   },
-  "navbar": {
-    "links": [
-      {
-        "label": "Explore Integrations",
-        "href": "https://world.org/ecosystem"
-      }
-    ],
-    "primary": {
-      "type": "button",
-      "label": "Developer Portal",
-      "href": "https://developer.worldcoin.org"
-    }
-  },
   "footer": {
     "socials": {
       "x": "https://x.com/worldnetwork",

--- a/tailwind.css
+++ b/tailwind.css
@@ -608,6 +608,15 @@
   #footer.advanced-footer div[class*="min-w-[140px]"] {
     display: none !important;
   }
+  /* The design's footer is the single links row only: drop the theme's
+     bottom utility row (Powered by Mintlify + theme icons) and its
+     divider. Branding removal is a paid-plan Mintlify feature — if the
+     org's plan requires attribution, revert this rule or use the
+     dashboard's hide-branding toggle instead. */
+  #footer.advanced-footer > div > div.h-px,
+  #footer.advanced-footer > div > div:last-child {
+    display: none !important;
+  }
   @media (max-width: 900px) {
     .landing-footer-inner {
       padding: 0 24px 48px;

--- a/tailwind.css
+++ b/tailwind.css
@@ -259,17 +259,18 @@
       border-color: rgba(255, 255, 255, 0.15) !important;
       color: #F3F2F0 !important;
     }
-    /* The design's header right side is just the Search / Ask pills:
-       no Explore Integrations link (Ecosystem lives in the Resources
-       menu and the footer), no Developer Portal CTA (moved into the
-       Resources menu at these widths), no theme toggle (the theme still
-       follows the system preference; both remain below 1440px). */
-    #navbar li.navbar-link,
-    #navbar #topbar-cta-button,
-    #navbar #theme-preference-menu-trigger,
+    /* The emptied right-hand group collapses inside the pill. */
     #navbar div.lg\:px-12 > div > div.justify-end {
       display: none !important;
     }
+  }
+  /* The header chrome is identical at every size, per the design: no
+     Explore Integrations link and no Developer Portal CTA (both removed
+     from docs.json navbar — Ecosystem and Developer Portal live in the
+     Resources menu and footer), and no theme toggle (the theme follows
+     the system preference). */
+  #navbar #theme-preference-menu-trigger {
+    display: none !important;
   }
 
   /* Quickstart: tighten code block spacing within the card */

--- a/tailwind.css
+++ b/tailwind.css
@@ -626,7 +626,9 @@
       padding: 64px 24px;
     }
     .landing-footer-links {
-      gap: 80px !important;
+      /* Wrapped rows stay together: the trademark line sits inline with
+         the links instead of floating far above them. */
+      gap: 16px 40px !important;
     }
   }
   @media (max-width: 600px) {
@@ -647,7 +649,7 @@
       font-size: 18px !important;
     }
     .landing-footer-links {
-      gap: 60px !important;
+      gap: 12px 32px !important;
     }
   }
 

--- a/tailwind.css
+++ b/tailwind.css
@@ -158,9 +158,15 @@
   /* the logo, the tab row, and the search/assistant cluster lay out on  */
   /* ONE flex line — no absolute positioning, so the variable-width      */
   /* hosted cluster (Search + Ask Assistant) can never overlap the tabs. */
-  /* Below 1440px the two-row layout above remains.                      */
+  /* Below 1440px — including when the hosted assistant panel narrows    */
+  /* the page without changing the window width — the two-row layout     */
+  /* above remains: the pill activates on the header's own width via a   */
+  /* container query, not a viewport media query.                        */
   /* ------------------------------------------------------------------ */
-  @media (min-width: 1440px) {
+  #navbar {
+    container-type: inline-size;
+  }
+  @container (min-width: 1440px) {
     /* No full-width backdrop: the pill floats on the page background. */
     #navbar #navbar-transition {
       display: none;
@@ -170,10 +176,11 @@
       display: flex;
       align-items: center;
       column-gap: 16px;
-      /* Side margins scale with the viewport (the design frame's 63/1728
-         ratio) instead of stepping at a breakpoint, so the pill keeps the
-         same proportions as the window shrinks. */
-      width: calc(100% - 7.3vw);
+      /* Side margins scale with the header's own width (the design
+         frame's 63/1728 ratio), so the pill keeps the same proportions
+         as the window — or the page area beside the assistant panel —
+         shrinks. */
+      width: calc(100% - 7.3cqw);
       max-width: 1602px !important;
       height: 84px;
       margin: 24px auto 0;
@@ -200,10 +207,14 @@
       order: 1;
       flex: 0 0 auto !important;
     }
+    #navbar .nav-tabs-item {
+      white-space: nowrap;
+    }
     #navbar .max-w-8xl > div > div.px-12 {
       order: 2;
       position: static;
       width: max-content;
+      flex-shrink: 0;
       height: auto !important;
       padding: 0 !important;
       margin-left: auto;


### PR DESCRIPTION
Two follow-up fixes to the merged #172 pill header, both from QA on the deployed preview:

## 1. Tab labels wrapped when the Ask Assistant panel opened

The panel narrows the page ~390px **without changing the window width**, so the pill's viewport media query stayed active in a ~1340px slot and the tab labels wrapped inside their pills.

**Fix:** `#navbar` becomes an inline-size **container** and the pill activates on a **container query** — the header responds to its own width. Panel open (or any narrowing below 1440px) → the two-row fallback returns cleanly. Margins scale in `cqw` (the design's 63/1728 ratio of the header's own width); the tab row is `nowrap`/no-shrink as belt and braces; browsers without container-query support degrade to the two-row header.

Verified by simulation: window 1728px, header constrained to 1338px → pill deactivates, no wrapping.

## 2. Explore Integrations / Developer Portal / theme toggle reappeared below the pill breakpoint

They were hidden only *inside* the pill rules, so the two-row fallback (smaller windows, assistant panel open) showed them again — an inconsistent header.

**Fix:** remove the `navbar` links/CTA from docs.json entirely (Developer Portal and Ecosystem live in the **Resources** menu and the footer) and hide the theme toggle globally. One identical header at every size: logo · tabs · Search · Ask Assistant. Dark mode still follows the system preference.

Verified at 1300px (fallback) and 1728px (pill): no Explore/Portal/toggle at either; pill geometry unchanged.

Recommend merging promptly — main currently ships the pill header with the panel-wrap bug.
